### PR TITLE
Feat/mesh replacement fix

### DIFF
--- a/UnBox3D/Commands/SetReplaceStateCommand.cs
+++ b/UnBox3D/Commands/SetReplaceStateCommand.cs
@@ -1,4 +1,4 @@
-﻿using UnBox3D.Controls.States;
+using UnBox3D.Controls.States;
 using UnBox3D.Controls;
 using UnBox3D.Models;
 using UnBox3D.Rendering;
@@ -15,8 +15,9 @@ namespace UnBox3D.Commands
         private ICamera _camera;
         private IRayCaster _rayCaster;
         private ICommandHistory _moveCommandHistory;
+        private string _shape;
 
-        public SetReplaceStateCommand(IGLControlHost glControlHost, MouseController mouseController, ISceneManager sceneManager, IRayCaster rayCaster, ICamera camera, ICommandHistory commandHistory)
+        public SetReplaceStateCommand(IGLControlHost glControlHost, MouseController mouseController, ISceneManager sceneManager, IRayCaster rayCaster, ICamera camera, ICommandHistory commandHistory, string shape)
         {
             _mouseController = mouseController;
             _sceneManager = sceneManager;
@@ -24,11 +25,12 @@ namespace UnBox3D.Commands
             _camera = camera;
             _moveCommandHistory = commandHistory;
             _gLControlHost = glControlHost;
+            _shape = shape;
         }
 
         public void Execute()
         {
-            var replaceState = new ReplaceState(_gLControlHost, _sceneManager, _camera, new RayCaster(_gLControlHost, _camera), _moveCommandHistory);
+            var replaceState = new ReplaceState(_gLControlHost, _sceneManager, _camera, new RayCaster(_gLControlHost, _camera), _moveCommandHistory, _shape);
             _mouseController.SetState(replaceState);
         }
 

--- a/UnBox3D/Controls/States/ReplaceState.cs
+++ b/UnBox3D/Controls/States/ReplaceState.cs
@@ -1,4 +1,4 @@
-﻿using OpenTK;
+using OpenTK;
 using System.Collections.Generic;
 using System.Windows.Forms;
 using g3;
@@ -19,20 +19,22 @@ namespace UnBox3D.Controls.States
         private readonly IRayCaster _rayCaster;
         private readonly ICamera _camera;
         private ICommandHistory _commandHistory;
+        private readonly string _shape;
 
 
-        public ReplaceState(IGLControlHost glControlHost, ISceneManager sceneManager, ICamera camera, IRayCaster rayCaster, ICommandHistory commandHistory)
+        public ReplaceState(IGLControlHost glControlHost, ISceneManager sceneManager, ICamera camera, IRayCaster rayCaster, ICommandHistory commandHistory, string shape)
         {
             _glControlHost = glControlHost;
             _sceneManager = sceneManager;
             _camera = camera;
             _rayCaster = rayCaster;
             _commandHistory = commandHistory;
+            _shape = shape;
         }
 
         public void OnMouseDown(MouseEventArgs e)
         {
-            ICommand replaceCommand = new ReplaceCommand(_glControlHost, _sceneManager, _rayCaster, _camera);
+            ICommand replaceCommand = new ReplaceCommand(_glControlHost, _sceneManager, _rayCaster, _camera, _shape);
             _commandHistory.PushCommand(replaceCommand);
             replaceCommand.Execute();
         }

--- a/UnBox3D/ViewModels/MainViewModel.cs
+++ b/UnBox3D/ViewModels/MainViewModel.cs
@@ -632,6 +632,39 @@ namespace UnBox3D.ViewModels
             await ShowWpfMessageBoxAsync("Replaced!", "Replace", MessageBoxButton.OK, MessageBoxImage.Information);
         }
 
+        [RelayCommand]
+         private async void ReplaceWithCubeOption(IAppMesh mesh)
+         {
+             Vector3 center = _sceneManager.GetMeshCenter(mesh.GetG4Mesh());
+             Vector3 meshDimensions = _sceneManager.GetMeshDimensions(mesh.GetG4Mesh());
+        
+             AppMesh cube = GeometryGenerator.CreateBox(
+                         center,
+                         meshDimensions.X,
+                         meshDimensions.Y,
+                         meshDimensions.Z
+                     );
+        
+             var summaryToRemove = Meshes.FirstOrDefault(ms => ms.SourceMesh == mesh);
+             if (summaryToRemove != null)
+             {
+                 Meshes.Remove(summaryToRemove);
+             }
+        
+             _sceneManager.ReplaceMesh(mesh, cube);
+        
+             Meshes.Add(new MeshSummary(cube));
+         }
+
+         [RelayCommand]
+         private async void ReplaceWithCubeClick()
+         {
+             var command = new SetReplaceStateCommand(_glControlHost, _mouseController, _sceneManager, new RayCaster(_glControlHost, _camera), _camera, _commandHistory, "cube");
+             
+             command.Execute();
+             await ShowWpfMessageBoxAsync("Replaced!", "Replace", MessageBoxButton.OK, MessageBoxImage.Information);
+         }
+
 
         [RelayCommand]
         private async Task SimplifyQEC(IAppMesh mesh)

--- a/UnBox3D/Views/MainWindow.xaml
+++ b/UnBox3D/Views/MainWindow.xaml
@@ -167,7 +167,9 @@
                                               CommandParameter="{Binding SourceMesh}" />
 
                                     <MenuItem Header="Replace with...">
-                                        <MenuItem Header="Cube" />
+                                         <MenuItem Header="Cube" Command="{Binding PlacementTarget.Tag.ReplaceWithCubeOptionCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                                                   CommandParameter="{Binding SourceMesh}"
+                                                   ToolTip="Replaces this mesh with a cube of the same size and orientation."/> 
                                         <MenuItem Header="Cylinder" Command="{Binding PlacementTarget.Tag.ReplaceWithCylinderOptionCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
                                                   CommandParameter="{Binding SourceMesh}"
                                                   ToolTip="Replaces this mesh with a cylinder of the same size and orientation."/>


### PR DESCRIPTION
I made edits to 5 different files found in the Commands folder, Controls/States, ViewModels, and Views and those are: SetReplaceStateCommand.cs, ReplaceState.cs, ReplaceCommand.cs, MainViewModel.cs, and MainWindow.xaml. For the first three listed, I added an extra parameter to their constructor to include a string called _shape which gets passed down from SetReplaceStateCommand to ReplaceState and finally ReplaceCommand, which will tell it what shape to replace the selected mesh with (a cube or a cylinder). ReplaceCommand was changed further to include and if-else statement to distinguish between "cube" or "cylinder" and perform the appropriate replacement (where before only the option for cylinder existed).

Realizing these changes, while correct, did nothing when running the application, I soon realized it had to do with the UI, which brings me to the other two classes. MainViewModel had a method called ReplaceWithCylinderOption() and ReplaceWithCylinderClick() to handle cylinder replacement when the user clicked on the option in the app, but had none for cube; I promptly changed it (taking inspiration from the aforementioned methods). Still, it didn't work, then I realized it was to do with MainWindow.xaml where the option for cylinder had a reference to MainViewModel but not cube. Upon adding that reference to the cube option, it was finally good to go.