### PR TITLE
Blender exe selection redo

### DIFF
--- a/UnBox3D/Utils/IBlenderInstaller.cs
+++ b/UnBox3D/Utils/IBlenderInstaller.cs
@@ -39,7 +39,11 @@ namespace UnBox3D.Utils
                     , "Blender Foundation", "blender-4.2", "blender.exe"); // this will be updated if found
             BlenderZipPath = _fileSystem.CombinePaths(baseDir, "blender.zip");
 
-            #region Standard Program Files path (version-independent)
+            FindAndSetBlender();
+        }
+
+        private void FindAndSetBlender()
+        {
             // 1. Try to find 'Blender Foundation' in Program Files
             string blenderFoundationPath = Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
@@ -65,7 +69,13 @@ namespace UnBox3D.Utils
                         );
                 }
             }
+            else return;
 
+            SetBlenderExecutable();
+        }
+
+        private void SetBlenderExecutable()
+        {
             // Optional: if ProgramFilesBlenderExecutable exists, set BlenderExecutable to it
             if (_fileSystem.DoesFileExists(ProgramFilesBlenderExecutable))
             {
@@ -73,10 +83,7 @@ namespace UnBox3D.Utils
                 BlenderFolder = Path.GetDirectoryName(Path.GetDirectoryName(BlenderExecutable)) ?? BlenderFolder;
                 Debug.WriteLine($"Using Blender from Program Files: {ProgramFilesBlenderExecutable}");
             }
-
         }
-
-            #endregion
 
         public Task CheckAndInstallBlender()
         {

--- a/UnBox3D/Utils/IBlenderInstaller.cs
+++ b/UnBox3D/Utils/IBlenderInstaller.cs
@@ -23,7 +23,7 @@ namespace UnBox3D.Utils
         private string ProgramFilesBlenderExecutable;
         private readonly string BlenderZipPath;
         public string ExecutablePath => BlenderExecutable;
-        private static readonly string BlenderDownloadUrl = "https://download.blender.org/release/Blender4.2/blender-4.2.0-windows-x64.zip";
+        private static readonly string BlenderDownloadUrl = "https://download.blender.org/release/Blender4.5/blender-4.5.3-windows-x64.zip";
         // Quick test URL for invalid URL handling
         //private static string BlenderDownloadUrl = "https://invalid.url.fake/blender.zip";
         private Task? _blenderInstallTask;
@@ -34,9 +34,9 @@ namespace UnBox3D.Utils
 
             string baseDir = AppDomain.CurrentDomain.BaseDirectory;
             BlenderFolder = _fileSystem.CombinePaths(baseDir, "Blender");
-            BlenderExecutable = _fileSystem.CombinePaths(BlenderFolder, "blender-4.2.0-windows-x64", "blender.exe");
+            BlenderExecutable = _fileSystem.CombinePaths(BlenderFolder, "blender-4.5.3-windows-x64", "blender.exe");
             ProgramFilesBlenderExecutable = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles)
-                    , "Blender Foundation", "blender-4.2", "blender.exe"); // this will be updated if found
+                    , "Blender Foundation", "blender-4.5.3", "blender.exe"); // this will be updated if found
             BlenderZipPath = _fileSystem.CombinePaths(baseDir, "blender.zip");
 
             FindAndSetBlender();
@@ -104,12 +104,12 @@ namespace UnBox3D.Utils
         {
             if (!_fileSystem.DoesDirectoryExists(BlenderFolder) || !_fileSystem.DoesFileExists(BlenderExecutable))
             {
-                Debug.WriteLine("Blender 4.2 is not installed. Downloading now...");
+                Debug.WriteLine("Blender 4.5 is not installed. Downloading now...");
                 await DownloadAndExtractBlender();
             }
             else
             {
-                Debug.WriteLine("Blender 4.2 is already installed.");
+                Debug.WriteLine("Blender 4.5 is already installed.");
             }
         }
 
@@ -128,7 +128,7 @@ namespace UnBox3D.Utils
             
             if (!_fileSystem.DoesDirectoryExists(BlenderFolder) || !_fileSystem.DoesFileExists(BlenderExecutable))
             {
-                Debug.WriteLine("Blender 4.2 is not installed. Downloading now...");
+                Debug.WriteLine("Blender 4.5 is not installed. Downloading now...");
 
                 try
                 {
@@ -143,7 +143,7 @@ namespace UnBox3D.Utils
             }
             else
             {
-                Debug.WriteLine("Blender 4.2 is already installed.");
+                Debug.WriteLine("Blender 4.5 is already installed.");
                 progress?.Report(1.0);
             }
         }


### PR DESCRIPTION
-Allow auto-detection of Blender in Program Files folder.
-Various bug fixes to addon installation, to prevent program failure when multiple addon versions are detected or enabled at once