### PR TITLE
Fix drag-and-drop OBJ import

### DIFF
--- a/UnBox3D/Views/MainWindow.xaml
+++ b/UnBox3D/Views/MainWindow.xaml
@@ -7,7 +7,11 @@
         Height="600"
         Width="800"
         WindowStartupLocation="CenterScreen"
-        Icon="pack://application:,,,/Assets/Icons/logo.ico">
+        Icon="pack://application:,,,/Assets/Icons/logo.ico"
+        AllowDrop="True"
+        DragOver="Window_DragOver"
+        Drop="Window_Drop">
+
 
 
     <DockPanel>


### PR DESCRIPTION
What it does: Adds drag-and-drop OBJ support so dropping an OBJ file into the app imports/loads it immediately.

Testing: Launch the app, drag an .obj file onto the window, and verify the model loads without needing the file picker. Try 2–3 different OBJ files.

