### PR TITLE
feat: snap back, deselect, precise transforms, scale & info panel, unit system, highlight fix

### DIFF
--- a/UnBox3D/Commands/PreciseMoveCommand.cs
+++ b/UnBox3D/Commands/PreciseMoveCommand.cs
@@ -1,0 +1,20 @@
+using OpenTK.Mathematics;
+using UnBox3D.Rendering;
+
+namespace UnBox3D.Commands
+{
+    public class PreciseMoveCommand : ICommand
+    {
+        private readonly IAppMesh _mesh;
+        private readonly Vector3  _delta;
+
+        public PreciseMoveCommand(IAppMesh mesh, Vector3 delta)
+        {
+            _mesh  = mesh ?? throw new ArgumentNullException(nameof(mesh));
+            _delta = delta;
+        }
+
+        public void Execute() => _mesh.Translate(_delta);
+        public void Undo()    => _mesh.Translate(-_delta);
+    }
+}

--- a/UnBox3D/Commands/PreciseRotateCommand.cs
+++ b/UnBox3D/Commands/PreciseRotateCommand.cs
@@ -1,0 +1,22 @@
+using OpenTK.Mathematics;
+using UnBox3D.Rendering;
+
+namespace UnBox3D.Commands
+{
+    public class PreciseRotateCommand : ICommand
+    {
+        private readonly IAppMesh   _mesh;
+        private readonly Quaternion _rotation;
+        private readonly Quaternion _inverse;
+
+        public PreciseRotateCommand(IAppMesh mesh, Quaternion rotation)
+        {
+            _mesh     = mesh ?? throw new ArgumentNullException(nameof(mesh));
+            _rotation = rotation;
+            _inverse  = Quaternion.Invert(rotation);
+        }
+
+        public void Execute() => _mesh.Rotate(_rotation);
+        public void Undo()    => _mesh.Rotate(_inverse);
+    }
+}

--- a/UnBox3D/Commands/ScaleCommand.cs
+++ b/UnBox3D/Commands/ScaleCommand.cs
@@ -1,0 +1,30 @@
+using OpenTK.Mathematics;
+using UnBox3D.Rendering;
+
+namespace UnBox3D.Commands
+{
+    public class ScaleCommand : ICommand
+    {
+        private readonly IAppMesh _mesh;
+        private readonly Vector3  _scaleFactors;
+        private readonly Vector3  _inverseFactors;
+
+        public ScaleCommand(IAppMesh mesh, Vector3 scaleFactors)
+        {
+            _mesh = mesh ?? throw new ArgumentNullException(nameof(mesh));
+
+            _scaleFactors = new Vector3(
+                scaleFactors.X == 0f ? 1f : scaleFactors.X,
+                scaleFactors.Y == 0f ? 1f : scaleFactors.Y,
+                scaleFactors.Z == 0f ? 1f : scaleFactors.Z);
+
+            _inverseFactors = new Vector3(
+                1f / _scaleFactors.X,
+                1f / _scaleFactors.Y,
+                1f / _scaleFactors.Z);
+        }
+
+        public void Execute() => _mesh.Scale(_scaleFactors);
+        public void Undo()    => _mesh.Scale(_inverseFactors);
+    }
+}

--- a/UnBox3D/Commands/SnapBackCommand.cs
+++ b/UnBox3D/Commands/SnapBackCommand.cs
@@ -1,0 +1,39 @@
+using OpenTK.Mathematics;
+using UnBox3D.Rendering;
+
+namespace UnBox3D.Commands
+{
+    public class SnapBackCommand : ICommand
+    {
+        private readonly IAppMesh _mesh;
+
+        private Vector3    _preSnapRenderCenter;
+        private Quaternion _preSnapTransform;
+        private bool       _executed = false;
+
+        public SnapBackCommand(IAppMesh mesh)
+        {
+            _mesh = mesh ?? throw new ArgumentNullException(nameof(mesh));
+        }
+
+        public void Execute()
+        {
+            _preSnapRenderCenter = _mesh.GetRenderCenter();
+            _preSnapTransform    = _mesh.GetTransform();
+            _executed = true;
+            _mesh.SnapToOrigin();
+        }
+
+        public void Undo()
+        {
+            if (!_executed) return;
+
+            _mesh.SetTransform(_preSnapTransform);
+
+            // Render-space delta back to world space (swap Y/Z).
+            Vector3 renderDiff = _preSnapRenderCenter - _mesh.GetRenderCenter();
+            Vector3 worldDelta = new Vector3(renderDiff.X, renderDiff.Z, renderDiff.Y);
+            _mesh.Translate(worldDelta);
+        }
+    }
+}

--- a/UnBox3D/Controls/States/DefaultState.cs
+++ b/UnBox3D/Controls/States/DefaultState.cs
@@ -17,13 +17,18 @@ namespace UnBox3D.Controls.States
         private readonly IGLControlHost _glControlHost;
         private readonly ICamera _camera;
         private readonly IRayCaster _rayCaster;
+        private readonly IRenderer? _renderer;
+        private readonly Action<IAppMesh?>? _onSelectionChanged;
 
-        public DefaultState ( ISceneManager sceneManager, IGLControlHost glControlHost, ICamera camera, IRayCaster rayCaster)
+        public DefaultState(ISceneManager sceneManager, IGLControlHost glControlHost, ICamera camera, IRayCaster rayCaster,
+            IRenderer? renderer = null, Action<IAppMesh?>? onSelectionChanged = null)
         {
             _sceneManager = sceneManager;
             _glControlHost = glControlHost;
             _rayCaster = rayCaster;
             _camera = camera;
+            _renderer = renderer;
+            _onSelectionChanged = onSelectionChanged;
         }
 
         public void OnMouseDown(MouseEventArgs e)
@@ -35,9 +40,14 @@ namespace UnBox3D.Controls.States
             // Check for intersection with the model
             if (_rayCaster.RayIntersectsMesh(_sceneManager.GetMeshes(), rayOrigin, rayWorld, out float distance, out IAppMesh selectedMesh))
             {
-                //sceneRenderer.ChangeMeshColor(clickedMesh, meshHighlightColor);
-                //sceneManager.SimplifyMesh(selectedMesh);
                 _glControlHost.Invalidate(); // Re-render
+            }
+            else
+            {
+                // Click missed all meshes — clear selection.
+                _onSelectionChanged?.Invoke(null);
+                _renderer?.SetActiveGizmoMesh(null);
+                _glControlHost.Invalidate();
             }
         }
 

--- a/UnBox3D/Controls/States/GimbalState.cs
+++ b/UnBox3D/Controls/States/GimbalState.cs
@@ -50,12 +50,13 @@ namespace UnBox3D.Controls.States
         private const float  ArrowPx      = 24f;   // pixel radius — arrow tip hit area
         private const float  RingLinePx   = 14f;   // pixel radius — ring line hit area
 
-        private readonly IGLControlHost  _controlHost;
-        private readonly ISceneManager   _sceneManager;
-        private readonly ICamera         _camera;
-        private readonly IRayCaster      _rayCaster;
-        private readonly ICommandHistory _commandHistory;
-        private readonly IRenderer       _renderer;
+        private readonly IGLControlHost    _controlHost;
+        private readonly ISceneManager     _sceneManager;
+        private readonly ICamera           _camera;
+        private readonly IRayCaster        _rayCaster;
+        private readonly ICommandHistory   _commandHistory;
+        private readonly IRenderer         _renderer;
+        private readonly Action<IAppMesh?>? _onSelectionChanged;
 
         private IAppMesh?      _selectedMesh;
         private GimbalDragMode _dragMode = GimbalDragMode.None;
@@ -69,19 +70,21 @@ namespace UnBox3D.Controls.States
         // ── Constructor ────────────────────────────────────────────────────
 
         public GimbalState(
-            IGLControlHost  controlHost,
-            ISceneManager   sceneManager,
-            ICamera         camera,
-            IRayCaster      rayCaster,
-            ICommandHistory commandHistory,
-            IRenderer       renderer)
+            IGLControlHost    controlHost,
+            ISceneManager     sceneManager,
+            ICamera           camera,
+            IRayCaster        rayCaster,
+            ICommandHistory   commandHistory,
+            IRenderer         renderer,
+            Action<IAppMesh?>? onSelectionChanged = null)
         {
-            _controlHost    = controlHost    ?? throw new ArgumentNullException(nameof(controlHost));
-            _sceneManager   = sceneManager   ?? throw new ArgumentNullException(nameof(sceneManager));
-            _camera         = camera         ?? throw new ArgumentNullException(nameof(camera));
-            _rayCaster      = rayCaster      ?? throw new ArgumentNullException(nameof(rayCaster));
-            _commandHistory = commandHistory ?? throw new ArgumentNullException(nameof(commandHistory));
-            _renderer       = renderer       ?? throw new ArgumentNullException(nameof(renderer));
+            _controlHost        = controlHost    ?? throw new ArgumentNullException(nameof(controlHost));
+            _sceneManager       = sceneManager   ?? throw new ArgumentNullException(nameof(sceneManager));
+            _camera             = camera         ?? throw new ArgumentNullException(nameof(camera));
+            _rayCaster          = rayCaster      ?? throw new ArgumentNullException(nameof(rayCaster));
+            _commandHistory     = commandHistory ?? throw new ArgumentNullException(nameof(commandHistory));
+            _renderer           = renderer       ?? throw new ArgumentNullException(nameof(renderer));
+            _onSelectionChanged = onSelectionChanged;
         }
 
         /// <summary>
@@ -145,6 +148,7 @@ namespace UnBox3D.Controls.States
                 }
 
                 _selectedMesh = clickedMesh;
+                _onSelectionChanged?.Invoke(_selectedMesh);
                 _renderer.SetActiveGizmoMesh(_selectedMesh);
                 _dragMode     = GimbalDragMode.FreeDrag;
                 _worldScale   = WorldScaleFromCamera();
@@ -166,6 +170,7 @@ namespace UnBox3D.Controls.States
                 {
                     _selectedMesh       = null;
                     _lastHoveredElement = GizmoHoverElement.None;
+                    _onSelectionChanged?.Invoke(null);
                     _renderer.SetActiveGizmoMesh(null);   // also resets hover in SceneRenderer
                     _controlHost.SetCursor(Cursors.Default);
                     _controlHost.Invalidate();

--- a/UnBox3D/Controls/States/GimbalState.cs
+++ b/UnBox3D/Controls/States/GimbalState.cs
@@ -95,6 +95,7 @@ namespace UnBox3D.Controls.States
         {
             _selectedMesh = mesh;
             _renderer.SetActiveGizmoMesh(mesh);
+            _renderer.SetGizmoMode(GizmoMode.Full);
             _worldScale   = WorldScaleFromCamera();
         }
 
@@ -150,6 +151,7 @@ namespace UnBox3D.Controls.States
                 _selectedMesh = clickedMesh;
                 _onSelectionChanged?.Invoke(_selectedMesh);
                 _renderer.SetActiveGizmoMesh(_selectedMesh);
+                _renderer.SetGizmoMode(GizmoMode.Full);
                 _dragMode     = GimbalDragMode.FreeDrag;
                 _worldScale   = WorldScaleFromCamera();
                 ApplyCursor(_dragMode);

--- a/UnBox3D/Controls/States/MoveState.cs
+++ b/UnBox3D/Controls/States/MoveState.cs
@@ -21,12 +21,13 @@ namespace UnBox3D.Controls.States
         private const float ArrowPx    = 28f;   // hit radius for arrow shafts (px)
         private const float RingLinePx = 14f;   // not used but reserved
 
-        private readonly IGLControlHost  _controlHost;
-        private readonly ISceneManager   _sceneManager;
-        private readonly ICamera         _camera;
-        private readonly IRayCaster      _rayCaster;
-        private readonly ICommandHistory _commandHistory;
-        private readonly IRenderer       _renderer;
+        private readonly IGLControlHost   _controlHost;
+        private readonly ISceneManager    _sceneManager;
+        private readonly ICamera          _camera;
+        private readonly IRayCaster       _rayCaster;
+        private readonly ICommandHistory  _commandHistory;
+        private readonly IRenderer        _renderer;
+        private readonly Action<IAppMesh?>? _onSelectionChanged;
 
         private IAppMesh? _selectedMesh;
 
@@ -40,19 +41,21 @@ namespace UnBox3D.Controls.States
         private GizmoHoverElement  _lastHoveredElement = GizmoHoverElement.None;
 
         public MoveState(
-            IGLControlHost  controlHost,
-            ISceneManager   sceneManager,
-            ICamera         camera,
-            IRayCaster      rayCaster,
-            ICommandHistory commandHistory,
-            IRenderer       renderer)
+            IGLControlHost   controlHost,
+            ISceneManager    sceneManager,
+            ICamera          camera,
+            IRayCaster       rayCaster,
+            ICommandHistory  commandHistory,
+            IRenderer        renderer,
+            Action<IAppMesh?>? onSelectionChanged = null)
         {
-            _controlHost    = controlHost    ?? throw new ArgumentNullException(nameof(controlHost));
-            _sceneManager   = sceneManager   ?? throw new ArgumentNullException(nameof(sceneManager));
-            _camera         = camera         ?? throw new ArgumentNullException(nameof(camera));
-            _rayCaster      = rayCaster      ?? throw new ArgumentNullException(nameof(rayCaster));
-            _commandHistory = commandHistory ?? throw new ArgumentNullException(nameof(commandHistory));
-            _renderer       = renderer       ?? throw new ArgumentNullException(nameof(renderer));
+            _controlHost         = controlHost    ?? throw new ArgumentNullException(nameof(controlHost));
+            _sceneManager        = sceneManager   ?? throw new ArgumentNullException(nameof(sceneManager));
+            _camera              = camera         ?? throw new ArgumentNullException(nameof(camera));
+            _rayCaster           = rayCaster      ?? throw new ArgumentNullException(nameof(rayCaster));
+            _commandHistory      = commandHistory ?? throw new ArgumentNullException(nameof(commandHistory));
+            _renderer            = renderer       ?? throw new ArgumentNullException(nameof(renderer));
+            _onSelectionChanged  = onSelectionChanged;
         }
 
         /// <summary>
@@ -117,6 +120,7 @@ namespace UnBox3D.Controls.States
                 }
 
                 _selectedMesh = clickedMesh;
+                _onSelectionChanged?.Invoke(_selectedMesh);
                 _renderer.SetActiveGizmoMesh(_selectedMesh);
                 _renderer.SetGizmoMode(GizmoMode.ArrowsOnly);
                 _dragAxis     = DragAxis.Free;
@@ -134,6 +138,7 @@ namespace UnBox3D.Controls.States
                 {
                     _selectedMesh       = null;
                     _lastHoveredElement = GizmoHoverElement.None;
+                    _onSelectionChanged?.Invoke(null);
                     _renderer.SetActiveGizmoMesh(null);   // also resets hover in SceneRenderer
                     _controlHost.SetCursor(Cursors.Default);
                     _controlHost.Invalidate();

--- a/UnBox3D/Controls/States/RotateState.cs
+++ b/UnBox3D/Controls/States/RotateState.cs
@@ -22,13 +22,14 @@ namespace UnBox3D.Controls.States
         private const int   RingSamples = 24;   // sample points around each ring
         private const float RingLinePx  = 16f;  // hit radius for ring lines (px)
 
-        private readonly ISettingsManager _settingsManager;
-        private readonly ISceneManager   _sceneManager;
-        private readonly IGLControlHost  _controlHost;
-        private readonly ICamera         _camera;
-        private readonly IRayCaster      _rayCaster;
-        private readonly ICommandHistory _commandHistory;
-        private readonly IRenderer       _renderer;
+        private readonly ISettingsManager  _settingsManager;
+        private readonly ISceneManager     _sceneManager;
+        private readonly IGLControlHost    _controlHost;
+        private readonly ICamera           _camera;
+        private readonly IRayCaster        _rayCaster;
+        private readonly ICommandHistory   _commandHistory;
+        private readonly IRenderer         _renderer;
+        private readonly Action<IAppMesh?>? _onSelectionChanged;
 
         private IAppMesh? _selectedMesh;
 
@@ -41,21 +42,23 @@ namespace UnBox3D.Controls.States
         private GizmoHoverElement  _lastHoveredElement = GizmoHoverElement.None;
 
         public RotateState(
-            ISettingsManager settingsManager,
-            ISceneManager   sceneManager,
-            IGLControlHost  controlHost,
-            ICamera         camera,
-            IRayCaster      rayCaster,
-            ICommandHistory commandHistory,
-            IRenderer       renderer)
+            ISettingsManager   settingsManager,
+            ISceneManager      sceneManager,
+            IGLControlHost     controlHost,
+            ICamera            camera,
+            IRayCaster         rayCaster,
+            ICommandHistory    commandHistory,
+            IRenderer          renderer,
+            Action<IAppMesh?>? onSelectionChanged = null)
         {
-            _settingsManager     = settingsManager ?? throw new ArgumentNullException(nameof(settingsManager));
-            _sceneManager        = sceneManager    ?? throw new ArgumentNullException(nameof(sceneManager));
-            _controlHost         = controlHost     ?? throw new ArgumentNullException(nameof(controlHost));
-            _camera              = camera          ?? throw new ArgumentNullException(nameof(camera));
-            _rayCaster           = rayCaster       ?? throw new ArgumentNullException(nameof(rayCaster));
-            _commandHistory      = commandHistory  ?? throw new ArgumentNullException(nameof(commandHistory));
-            _renderer            = renderer        ?? throw new ArgumentNullException(nameof(renderer));
+            _settingsManager    = settingsManager ?? throw new ArgumentNullException(nameof(settingsManager));
+            _sceneManager       = sceneManager    ?? throw new ArgumentNullException(nameof(sceneManager));
+            _controlHost        = controlHost     ?? throw new ArgumentNullException(nameof(controlHost));
+            _camera             = camera          ?? throw new ArgumentNullException(nameof(camera));
+            _rayCaster          = rayCaster       ?? throw new ArgumentNullException(nameof(rayCaster));
+            _commandHistory     = commandHistory  ?? throw new ArgumentNullException(nameof(commandHistory));
+            _renderer           = renderer        ?? throw new ArgumentNullException(nameof(renderer));
+            _onSelectionChanged = onSelectionChanged;
 
             _rotationSensitivity = _settingsManager.GetSetting<float>(
                 new UISettings().GetKey(), UISettings.MeshRotationSensitivity);
@@ -119,6 +122,7 @@ namespace UnBox3D.Controls.States
                 }
 
                 _selectedMesh = clickedMesh;
+                _onSelectionChanged?.Invoke(_selectedMesh);
                 _renderer.SetActiveGizmoMesh(_selectedMesh);
                 _renderer.SetGizmoMode(GizmoMode.RingsOnly);
                 _rotateAxis   = RotateAxis.Free;   // default: drag = free Y-axis spin
@@ -136,6 +140,7 @@ namespace UnBox3D.Controls.States
                 {
                     _selectedMesh       = null;
                     _lastHoveredElement = GizmoHoverElement.None;
+                    _onSelectionChanged?.Invoke(null);
                     _renderer.SetActiveGizmoMesh(null);   // also resets hover in SceneRenderer
                     _controlHost.SetCursor(Cursors.Default);
                     _controlHost.Invalidate();

--- a/UnBox3D/Rendering/AppMesh.cs
+++ b/UnBox3D/Rendering/AppMesh.cs
@@ -1,4 +1,4 @@
-﻿using Assimp;
+using Assimp;
 using g4;
 using OpenTK.Graphics.OpenGL4;
 using OpenTK.Mathematics;
@@ -32,6 +32,10 @@ namespace UnBox3D.Rendering
         Vector3 GetRenderCenter();
         /// <summary>Returns the half-extents radius of the mesh in render space (largest dimension / 2).</summary>
         float GetRenderRadius();
+        Vector3 OriginalRenderCenter { get; }
+        void SnapToOrigin();
+        void SetTransform(Quaternion q);
+        void Scale(Vector3 scaleFactors);
         #endregion
 
         #region OpenGL Handles
@@ -55,6 +59,7 @@ namespace UnBox3D.Rendering
         private Quaternion _transform = Quaternion.Identity;
         private int _ebo;
         private int[] _indices;
+        private Vector3 _originalRenderCenter;
         #endregion
 
         #region Constructor
@@ -112,6 +117,9 @@ namespace UnBox3D.Rendering
             }
 
             SetupMesh();
+
+            // Capture the home position AFTER the vertex buffer is ready.
+            _originalRenderCenter = GetRenderCenter();
         }
         #endregion
 
@@ -186,6 +194,8 @@ namespace UnBox3D.Rendering
         public float[] Vertices => _vertices;
         public int GetVAO() => _vao;
         public int GetVBO() => _vertexBufferObject;
+
+        public Vector3 OriginalRenderCenter => _originalRenderCenter;
         #endregion
 
         #region Getters
@@ -233,6 +243,7 @@ namespace UnBox3D.Rendering
         public void SetName(string name) => _name = name;
         public void SetColor(Vector3 color) => _color = color;
         public void SetHighlighted(bool flag) => _highlighted = flag;
+        public void SetTransform(Quaternion q) { _transform = q; _transform.Normalize(); }
         #endregion
 
         #region Transformations
@@ -275,7 +286,52 @@ namespace UnBox3D.Rendering
             // 4. Re-upload updated buffer to the GPU.
             SetupMesh();
         }
+
+        public void SnapToOrigin()
+        {
+            _transform = Quaternion.Identity;
+            Vector3 renderDiff = _originalRenderCenter - GetRenderCenter();
+            // Render Y = world Z, render Z = world Y — swap when building the world-space delta.
+            Translate(new Vector3(renderDiff.X, renderDiff.Z, renderDiff.Y));
+        }
         #endregion
+
+        public void Scale(Vector3 scaleFactors)
+        {
+            Vector3 renderCenter = GetRenderCenter();
+            int stride = _assimpMesh.HasNormals ? 6 : 3;
+
+            for (int i = 0; i < _assimpMesh.VertexCount; i++)
+            {
+                int idx = i * stride;
+                _vertices[idx]     = renderCenter.X + (_vertices[idx]     - renderCenter.X) * scaleFactors.X;
+                _vertices[idx + 1] = renderCenter.Y + (_vertices[idx + 1] - renderCenter.Y) * scaleFactors.Y;
+                _vertices[idx + 2] = renderCenter.Z + (_vertices[idx + 2] - renderCenter.Z) * scaleFactors.Z;
+            }
+
+            // g4 world space: world X = render X, world Y = render Z, world Z = render Y
+            double cx = renderCenter.X, cy = renderCenter.Z, cz = renderCenter.Y;
+            for (int i = 0; i < _g4Mesh.VertexCount; i++)
+            {
+                var v = _g4Mesh.GetVertex(i);
+                _g4Mesh.SetVertex(i, new g4.Vector3d(
+                    cx + (v.x - cx) * scaleFactors.X,
+                    cy + (v.y - cy) * scaleFactors.Y,
+                    cz + (v.z - cz) * scaleFactors.Z));
+            }
+
+            float fcx = (float)cx, fcy = (float)cy, fcz = (float)cz;
+            for (int i = 0; i < _assimpMesh.VertexCount; i++)
+            {
+                var v = _assimpMesh.Vertices[i];
+                _assimpMesh.Vertices[i] = new Assimp.Vector3D(
+                    fcx + (v.X - fcx) * scaleFactors.X,
+                    fcy + (v.Y - fcy) * scaleFactors.Y,
+                    fcz + (v.Z - fcz) * scaleFactors.Z);
+            }
+
+            SetupMesh();
+        }
 
         #region MeshSimplification
 

--- a/UnBox3D/ViewModels/MainViewModel.cs
+++ b/UnBox3D/ViewModels/MainViewModel.cs
@@ -1663,6 +1663,10 @@ namespace UnBox3D.ViewModels
                     OnPropertyChanged(nameof(FormattedPreviewDims));
                 }
             };
+
+            // Replace the bare DI-registered DefaultState (no callbacks) with a properly
+            // wired one so deselection works from the very first interaction.
+            SetSelectMode();
         }
 
         #endregion
@@ -1674,7 +1678,8 @@ namespace UnBox3D.ViewModels
         {
             ActiveMode = "Select";
             _renderer.SetActiveGizmoMesh(null);
-            var state = new DefaultState(_sceneManager, _glControlHost, _camera, new RayCaster(_glControlHost, _camera));
+            var state = new DefaultState(_sceneManager, _glControlHost, _camera, new RayCaster(_glControlHost, _camera),
+                _renderer, NotifyStateSelectionChanged);
             _mouseController.SetState(state);
         }
 
@@ -1731,12 +1736,9 @@ namespace UnBox3D.ViewModels
             // If a mesh is already selected in the scene, show the gimbal rings immediately
             // without making the user click again.
             if (SelectedMesh != null)
-            {
                 state.SetSelectedMesh(SelectedMesh);
-                _glControlHost.Invalidate();
-            }
-
-            _renderer.SetGizmoMode(GizmoMode.Full);
+            else
+                _renderer.SetActiveGizmoMesh(null);
             _mouseController.SetState(state);
         }
 

--- a/UnBox3D/ViewModels/MainViewModel.cs
+++ b/UnBox3D/ViewModels/MainViewModel.cs
@@ -50,9 +50,6 @@ namespace UnBox3D.ViewModels
         private IAppMesh? selectedMesh;
 
         [ObservableProperty]
-        private bool hierarchyVisible = true;
-
-        [ObservableProperty]
         private float pageWidth = 25.0f;
 
         [ObservableProperty]
@@ -595,12 +592,6 @@ namespace UnBox3D.ViewModels
         }
 
         [RelayCommand]
-        private void ToggleHierarchy()
-        {
-            HierarchyVisible = !HierarchyVisible;
-        }
-
-        [RelayCommand]
         private static async Task About()
         {
             await ShowWpfMessageBoxAsync("UnBox3D - A 3D Model Viewer", "About", MessageBoxButton.OK, MessageBoxImage.Information);
@@ -687,6 +678,343 @@ namespace UnBox3D.ViewModels
             var summaryToRemove = Meshes.FirstOrDefault(ms => ms.SourceMesh == mesh);
             if (summaryToRemove != null)
                 Meshes.Remove(summaryToRemove);
+        }
+
+        // ── Deselect ───────────────────────────────────────────────────────────
+
+        [RelayCommand]
+        private void Deselect()
+        {
+            SelectedMeshSummary = null;
+            _renderer.SetActiveGizmoMesh(null);
+            _glControlHost.Render();
+        }
+
+        // ── Snap Back ──────────────────────────────────────────────────────────
+
+        [RelayCommand]
+        private void SnapBackMesh(IAppMesh mesh)
+        {
+            if (mesh == null) return;
+
+            var cmd = new SnapBackCommand(mesh);
+            _commandHistory.PushCommand(cmd);
+            cmd.Execute();
+
+            _renderer.SetActiveGizmoMesh(mesh);
+            _glControlHost.Render();
+            ToastService.Show($"'{mesh.Name}' snapped to original position.");
+        }
+
+        [RelayCommand]
+        private void SnapBackSelected()
+        {
+            if (SelectedMesh != null)
+                SnapBackMesh(SelectedMesh);
+            else
+                ToastService.Show("Select a mesh first.", isError: false);
+        }
+
+        // ── Precise Rotate ────────────────────────────────────────────────
+
+        [ObservableProperty] private string preciseRotateX = "0";
+        [ObservableProperty] private string preciseRotateY = "0";
+        [ObservableProperty] private string preciseRotateZ = "0";
+
+        [RelayCommand]
+        private void ApplyPreciseRotate()
+        {
+            if (SelectedMesh == null)
+            {
+                ToastService.Show("Select a mesh first.", isError: false);
+                return;
+            }
+
+            float x = float.TryParse(PreciseRotateX, System.Globalization.NumberStyles.Float,
+                           System.Globalization.CultureInfo.InvariantCulture, out float fx) ? fx : 0f;
+            float y = float.TryParse(PreciseRotateY, System.Globalization.NumberStyles.Float,
+                           System.Globalization.CultureInfo.InvariantCulture, out float fy) ? fy : 0f;
+            float z = float.TryParse(PreciseRotateZ, System.Globalization.NumberStyles.Float,
+                           System.Globalization.CultureInfo.InvariantCulture, out float fz) ? fz : 0f;
+
+            if (x == 0f && y == 0f && z == 0f)
+            {
+                ToastService.Show("All angles are 0 — nothing to rotate.", isError: false);
+                return;
+            }
+
+            // qZ * qY * qX applies X first, then Y, then Z
+            var qx = Quaternion.FromAxisAngle(Vector3.UnitX, MathHelper.DegreesToRadians(x));
+            var qy = Quaternion.FromAxisAngle(Vector3.UnitY, MathHelper.DegreesToRadians(y));
+            var qz = Quaternion.FromAxisAngle(Vector3.UnitZ, MathHelper.DegreesToRadians(z));
+            var combined = qz * qy * qx;
+            combined.Normalize();
+
+            var cmd = new PreciseRotateCommand(SelectedMesh, combined);
+            _commandHistory.PushCommand(cmd);
+            cmd.Execute();
+
+            _renderer.SetActiveGizmoMesh(SelectedMesh);
+            _glControlHost.Render();
+
+            var parts = new System.Text.StringBuilder();
+            if (x != 0f) parts.Append($"X:{x}° ");
+            if (y != 0f) parts.Append($"Y:{y}° ");
+            if (z != 0f) parts.Append($"Z:{z}°");
+            ToastService.Show($"Rotated '{SelectedMesh.Name}' by {parts.ToString().Trim()}");
+        }
+
+        // ── Mesh Info ────────────────────────────────────────────────
+
+        [ObservableProperty] private string selectedMeshInfoName = "";
+        [ObservableProperty] private string selectedMeshInfoVerts = "";
+        [ObservableProperty] private string selectedMeshInfoDims = "";
+
+        private void RefreshMeshInfo(IAppMesh? mesh)
+        {
+            if (mesh == null)
+            {
+                SelectedMeshInfoName  = "";
+                SelectedMeshInfoVerts = "";
+                SelectedMeshInfoDims  = "";
+                return;
+            }
+
+            SelectedMeshInfoName  = mesh.Name;
+            SelectedMeshInfoVerts = $"{mesh.VertexCount:N0} vertices";
+
+            try
+            {
+                Vector3 dim = _sceneManager.GetMeshDimensions(mesh.GetG4Mesh());
+                SelectedMeshInfoDims = $"W {dim.X:F2}   H {dim.Y:F2}   D {dim.Z:F2}";
+            }
+            catch
+            {
+                SelectedMeshInfoDims = "";
+            }
+        }
+
+        // ── Precise Move ───────────────────────────────────────────────
+
+        [ObservableProperty] private string preciseMoveX = "0";
+        [ObservableProperty] private string preciseMoveY = "0";
+        [ObservableProperty] private string preciseMoveZ = "0";
+
+        [RelayCommand]
+        private void ApplyPreciseMove()
+        {
+            if (SelectedMesh == null)
+            {
+                ToastService.Show("Select a mesh first.", isError: false);
+                return;
+            }
+
+            float x = float.TryParse(PreciseMoveX, System.Globalization.NumberStyles.Float,
+                           System.Globalization.CultureInfo.InvariantCulture, out float fx) ? fx : 0f;
+            float y = float.TryParse(PreciseMoveY, System.Globalization.NumberStyles.Float,
+                           System.Globalization.CultureInfo.InvariantCulture, out float fy) ? fy : 0f;
+            float z = float.TryParse(PreciseMoveZ, System.Globalization.NumberStyles.Float,
+                           System.Globalization.CultureInfo.InvariantCulture, out float fz) ? fz : 0f;
+
+            if (x == 0f && y == 0f && z == 0f)
+            {
+                ToastService.Show("All offsets are 0 — nothing to move.", isError: false);
+                return;
+            }
+
+            var delta = new Vector3(x, y, z);
+            var cmd   = new PreciseMoveCommand(SelectedMesh, delta);
+            _commandHistory.PushCommand(cmd);
+            cmd.Execute();
+
+            _renderer.SetActiveGizmoMesh(SelectedMesh);
+            _glControlHost.Render();
+            RefreshMeshInfo(SelectedMesh);
+            OnPropertyChanged(nameof(FormattedCoords));
+            OnPropertyChanged(nameof(FormattedDims));
+
+            var parts = new System.Text.StringBuilder();
+            if (x != 0f) parts.Append($"X:{x:+0.##;-0.##} ");
+            if (y != 0f) parts.Append($"Y:{y:+0.##;-0.##} ");
+            if (z != 0f) parts.Append($"Z:{z:+0.##;-0.##}");
+            ToastService.Show($"Moved '{SelectedMesh.Name}' by {parts.ToString().Trim()}");
+        }
+
+        // ── Scale ──────────────────────────────────────────────────────────────
+
+        [ObservableProperty] private string scaleValue = "1";
+        [ObservableProperty] private bool scaleAxisX = true;
+        [ObservableProperty] private bool scaleAxisY = true;
+        [ObservableProperty] private bool scaleAxisZ = true;
+
+        public string ScalePreviewDims
+        {
+            get
+            {
+                if (SelectedMesh == null) return "";
+
+                if (!float.TryParse(ScaleValue, System.Globalization.NumberStyles.Float,
+                        System.Globalization.CultureInfo.InvariantCulture, out float factor)
+                    || factor <= 0f)
+                    return "invalid factor";
+
+                try
+                {
+                    Vector3 dim = _sceneManager.GetMeshDimensions(SelectedMesh.GetG4Mesh());
+                    float nx = dim.X * (ScaleAxisX ? factor : 1f);
+                    float ny = dim.Y * (ScaleAxisY ? factor : 1f);
+                    float nz = dim.Z * (ScaleAxisZ ? factor : 1f);
+                    return $"W {nx:F2}   H {ny:F2}   D {nz:F2}";
+                }
+                catch { return ""; }
+            }
+        }
+
+        // Partial callbacks — fired by the MVVM source generator when the backing fields change.
+        partial void OnScaleValueChanged(string value)   { OnPropertyChanged(nameof(ScalePreviewDims)); OnPropertyChanged(nameof(FormattedPreviewDims)); }
+        partial void OnScaleAxisXChanged(bool value)     { OnPropertyChanged(nameof(ScalePreviewDims)); OnPropertyChanged(nameof(FormattedPreviewDims)); }
+        partial void OnScaleAxisYChanged(bool value)     { OnPropertyChanged(nameof(ScalePreviewDims)); OnPropertyChanged(nameof(FormattedPreviewDims)); }
+        partial void OnScaleAxisZChanged(bool value)     { OnPropertyChanged(nameof(ScalePreviewDims)); OnPropertyChanged(nameof(FormattedPreviewDims)); }
+
+        [RelayCommand]
+        private void ApplyScale()
+        {
+            if (SelectedMesh == null)
+            {
+                ToastService.Show("Select a mesh first.", isError: false);
+                return;
+            }
+
+            if (!float.TryParse(ScaleValue, System.Globalization.NumberStyles.Float,
+                    System.Globalization.CultureInfo.InvariantCulture, out float factor)
+                || factor <= 0f)
+            {
+                ToastService.Show("Enter a positive scale factor (e.g. 2 or 0.5).", isError: true);
+                return;
+            }
+
+            if (!ScaleAxisX && !ScaleAxisY && !ScaleAxisZ)
+            {
+                ToastService.Show("Enable at least one axis to scale.", isError: false);
+                return;
+            }
+
+            var scaleFactors = new Vector3(
+                ScaleAxisX ? factor : 1f,
+                ScaleAxisY ? factor : 1f,
+                ScaleAxisZ ? factor : 1f);
+
+            var cmd = new ScaleCommand(SelectedMesh, scaleFactors);
+            _commandHistory.PushCommand(cmd);
+            cmd.Execute();
+
+            _renderer.SetActiveGizmoMesh(SelectedMesh);
+            _glControlHost.Render();
+            RefreshMeshInfo(SelectedMesh);
+            OnPropertyChanged(nameof(FormattedDims));
+            OnPropertyChanged(nameof(FormattedCoords));
+
+            var axes = (ScaleAxisX ? "X" : "") + (ScaleAxisY ? "Y" : "") + (ScaleAxisZ ? "Z" : "");
+            ToastService.Show($"Scaled '{SelectedMesh.Name}' ×{factor} on {axes}");
+        }
+
+        // ── Unit System + Scale & Info Panel ───────────────────────────────────────
+
+        [ObservableProperty] private string selectedUnit = "Meters";
+        [ObservableProperty] private bool isScaleInfoPanelOpen = false;
+
+        public static string[] UnitOptions { get; } =
+            { "Meters", "Centimeters", "Millimeters", "Inches", "Feet", "Miles" };
+
+        private static float GetUnitFactor(string unit) => unit switch
+        {
+            "Centimeters" => 100f,
+            "Millimeters" => 1000f,
+            "Inches"      => 39.3701f,
+            "Feet"        => 3.28084f,
+            "Miles"       => 0.000621371f,
+            _             => 1f
+        };
+
+        private static string GetUnitAbbrev(string unit) => unit switch
+        {
+            "Centimeters" => "cm",
+            "Millimeters" => "mm",
+            "Inches"      => "in",
+            "Feet"        => "ft",
+            "Miles"       => "mi",
+            _             => "m"
+        };
+
+        public string FormattedDims
+        {
+            get
+            {
+                if (SelectedMesh == null) return "";
+                try
+                {
+                    float f = GetUnitFactor(SelectedUnit);
+                    string u = GetUnitAbbrev(SelectedUnit);
+                    Vector3 dim = _sceneManager.GetMeshDimensions(SelectedMesh.GetG4Mesh());
+                    return $"W {dim.X * f:F2}{u}   H {dim.Y * f:F2}{u}   D {dim.Z * f:F2}{u}";
+                }
+                catch { return ""; }
+            }
+        }
+
+        public string FormattedCoords
+        {
+            get
+            {
+                if (SelectedMesh == null) return "";
+                try
+                {
+                    float f = GetUnitFactor(SelectedUnit);
+                    string u = GetUnitAbbrev(SelectedUnit);
+                    // render X = world X, render Y = world Z, render Z = world Y
+                    Vector3 c = SelectedMesh.GetRenderCenter();
+                    return $"X {c.X * f:F2}{u}   Y {c.Z * f:F2}{u}   Z {c.Y * f:F2}{u}";
+                }
+                catch { return ""; }
+            }
+        }
+
+        public string FormattedPreviewDims
+        {
+            get
+            {
+                if (SelectedMesh == null) return "";
+                if (!float.TryParse(ScaleValue, System.Globalization.NumberStyles.Float,
+                        System.Globalization.CultureInfo.InvariantCulture, out float factor)
+                    || factor <= 0f)
+                    return "invalid factor";
+                try
+                {
+                    float f = GetUnitFactor(SelectedUnit);
+                    string u = GetUnitAbbrev(SelectedUnit);
+                    Vector3 dim = _sceneManager.GetMeshDimensions(SelectedMesh.GetG4Mesh());
+                    float nx = dim.X * (ScaleAxisX ? factor : 1f) * f;
+                    float ny = dim.Y * (ScaleAxisY ? factor : 1f) * f;
+                    float nz = dim.Z * (ScaleAxisZ ? factor : 1f) * f;
+                    return $"W {nx:F2}{u}   H {ny:F2}{u}   D {nz:F2}{u}";
+                }
+                catch { return ""; }
+            }
+        }
+
+        // Recompute all formatted properties when the unit changes.
+        partial void OnSelectedUnitChanged(string value)
+        {
+            OnPropertyChanged(nameof(FormattedDims));
+            OnPropertyChanged(nameof(FormattedCoords));
+            OnPropertyChanged(nameof(FormattedPreviewDims));
+        }
+
+        [RelayCommand]
+        private void ToggleScaleInfoPanel()
+        {
+            if (SelectedMesh == null) return;
+            IsScaleInfoPanelOpen = !IsScaleInfoPanelOpen;
         }
 
 
@@ -1158,15 +1486,29 @@ namespace UnBox3D.ViewModels
             //    This ensures panel-driven selection updates the gizmo just like a viewport click.
             RetargetGizmoToSelectedMesh();
 
-            // 5) Ask the GL view to repaint so the color change shows immediately.
+            // 5) Notify dependents that require a mesh selection (e.g. Replace buttons in the UI).
+            OnPropertyChanged(nameof(HasSelectedMesh));
+
+            // 6) Refresh the info card and all formatted measurement properties.
+            RefreshMeshInfo(value);
+            OnPropertyChanged(nameof(ScalePreviewDims));
+            OnPropertyChanged(nameof(FormattedDims));
+            OnPropertyChanged(nameof(FormattedCoords));
+            OnPropertyChanged(nameof(FormattedPreviewDims));
+
+            // 7) Close the info panel when the selection is cleared.
+            if (value == null) IsScaleInfoPanelOpen = false;
+
+            // 8) Ask the GL view to repaint so the color change shows immediately.
             _glControlHost.Render();
         }
 
         /// <summary>
-        /// True while Move, Rotate, or Gimbal mode is the active mouse state.
-        /// Used by the MainWindow viewport click handler to avoid updating SelectedMesh
-        /// while the state machine owns mesh interaction.
+        /// True when a mesh is currently selected.  Used to enable / disable
+        /// UI controls that require a selection (Replace, Snap Back, etc.).
         /// </summary>
+        public bool HasSelectedMesh => SelectedMesh != null;
+
         public bool IsTransformModeActive =>
             _mouseController.GetState() is MoveState or RotateState or GimbalState;
 
@@ -1312,6 +1654,14 @@ namespace UnBox3D.ViewModels
             {
                 UndoActionCommand.NotifyCanExecuteChanged();
                 RedoActionCommand.NotifyCanExecuteChanged();
+
+                if (SelectedMesh != null)
+                {
+                    RefreshMeshInfo(SelectedMesh);
+                    OnPropertyChanged(nameof(FormattedCoords));
+                    OnPropertyChanged(nameof(FormattedDims));
+                    OnPropertyChanged(nameof(FormattedPreviewDims));
+                }
             };
         }
 
@@ -1341,7 +1691,10 @@ namespace UnBox3D.ViewModels
         private void SetMoveMode()
         {
             ActiveMode = "Move";
-            var state = new MoveState(_glControlHost, _sceneManager, _camera, new RayCaster(_glControlHost, _camera), _commandHistory, _renderer);
+            var state = new MoveState(
+                _glControlHost, _sceneManager, _camera,
+                new RayCaster(_glControlHost, _camera), _commandHistory, _renderer,
+                onSelectionChanged: NotifyStateSelectionChanged);
             // If a mesh is already selected, show arrows immediately — no need to click again.
             if (SelectedMesh != null)
                 state.SetSelectedMesh(SelectedMesh);
@@ -1354,7 +1707,10 @@ namespace UnBox3D.ViewModels
         private void SetRotateMode()
         {
             ActiveMode = "Rotate";
-            var state = new RotateState(_settingsManager, _sceneManager, _glControlHost, _camera, new RayCaster(_glControlHost, _camera), _commandHistory, _renderer);
+            var state = new RotateState(
+                _settingsManager, _sceneManager, _glControlHost, _camera,
+                new RayCaster(_glControlHost, _camera), _commandHistory, _renderer,
+                onSelectionChanged: NotifyStateSelectionChanged);
             // If a mesh is already selected, show rings immediately — no need to click again.
             if (SelectedMesh != null)
                 state.SetSelectedMesh(SelectedMesh);
@@ -1367,7 +1723,10 @@ namespace UnBox3D.ViewModels
         private void SetGimbalMode()
         {
             ActiveMode = "Gimbal";
-            var state = new GimbalState(_glControlHost, _sceneManager, _camera, new RayCaster(_glControlHost, _camera), _commandHistory, _renderer);
+            var state = new GimbalState(
+                _glControlHost, _sceneManager, _camera,
+                new RayCaster(_glControlHost, _camera), _commandHistory, _renderer,
+                onSelectionChanged: NotifyStateSelectionChanged);
 
             // If a mesh is already selected in the scene, show the gimbal rings immediately
             // without making the user click again.
@@ -1381,12 +1740,26 @@ namespace UnBox3D.ViewModels
             _mouseController.SetState(state);
         }
 
+        private void NotifyStateSelectionChanged(IAppMesh? mesh)
+        {
+            // Invoked from WinForms mouse thread — marshal to UI thread.
+            System.Windows.Application.Current.Dispatcher.Invoke(() =>
+            {
+                if (mesh == null)
+                {
+                    SelectedMeshSummary = null;
+                }
+                else
+                {
+                    var summary = Meshes.FirstOrDefault(ms => ReferenceEquals(ms.SourceMesh, mesh));
+                    if (summary != null)
+                        SelectedMeshSummary = summary;
+                }
+            });
+        }
+
         #endregion
 
-        /// <summary>
-        /// Rebuilds the Meshes observable collection from the current scene.
-        /// Called after undo/redo so the hierarchy stays in sync.
-        /// </summary>
         private void RefreshMeshesCollection()
         {
             Meshes.Clear();
@@ -1402,16 +1775,24 @@ namespace UnBox3D.ViewModels
                 return;
             }
 
+            // Remember which mesh was selected so we can restore it after the rebuild.
+            var previouslySelected = SelectedMesh;
+
             _sceneManager.RemoveSmallMeshes(_latestImportedModel, SmallMeshThreshold);
             Meshes.Clear();
 
-            var importedMeshes = _sceneManager.GetMeshes();
-
-            foreach (var mesh in importedMeshes)
-            {
+            foreach (var mesh in _sceneManager.GetMeshes())
                 Meshes.Add(new MeshSummary(mesh));
-            }
 
+            // Restore the selection if the mesh survived the threshold filter.
+            if (previouslySelected != null)
+            {
+                var restoredSummary = Meshes.FirstOrDefault(ms => ReferenceEquals(ms.SourceMesh, previouslySelected));
+                if (restoredSummary != null)
+                    SelectedMeshSummary = restoredSummary;
+                else
+                    SelectedMeshSummary = null;
+            }
         }
     }
 }

--- a/UnBox3D/ViewModels/_snapback_patch.cs
+++ b/UnBox3D/ViewModels/_snapback_patch.cs
@@ -1,0 +1,1 @@
+// Temporary scratch file — safe to delete.

--- a/UnBox3D/Views/HelpWindow.xaml
+++ b/UnBox3D/Views/HelpWindow.xaml
@@ -77,142 +77,54 @@
                            Margin="0,6,0,8"/>
                 <Border Style="{StaticResource CardBorderStyle}">
                     <UniformGrid Rows="1" Columns="2">
-
                         <!-- Left column -->
                         <StackPanel Margin="0,0,16,0">
-                            <Grid Margin="0,0,0,8">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="*"/>
-                                </Grid.ColumnDefinitions>
-                                <Border Style="{StaticResource KbdBadgeStyle}">
-                                    <TextBlock Text="Enter" FontFamily="Cascadia Code, Consolas"
-                                               FontSize="11" Foreground="{DynamicResource TextBrush}"/>
-                                </Border>
-                                <TextBlock Grid.Column="1" Text="Start session"
-                                           FontSize="12.5" Foreground="{DynamicResource AccentBrush}"
-                                           VerticalAlignment="Center"/>
+                            <Grid Margin="0,0,0,8"><Grid.ColumnDefinitions><ColumnDefinition Width="Auto"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
+                                <Border Style="{StaticResource KbdBadgeStyle}"><TextBlock Text="Ctrl+Z" FontFamily="Cascadia Code, Consolas" FontSize="11" Foreground="{DynamicResource TextBrush}"/></Border>
+                                <TextBlock Grid.Column="1" Text="Undo last action" FontSize="12.5" Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center"/>
                             </Grid>
-                            <Grid Margin="0,0,0,8">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="*"/>
-                                </Grid.ColumnDefinitions>
-                                <Border Style="{StaticResource KbdBadgeStyle}">
-                                    <TextBlock Text="Alt+O" FontFamily="Cascadia Code, Consolas"
-                                               FontSize="11" Foreground="{DynamicResource TextBrush}"/>
-                                </Border>
-                                <TextBlock Grid.Column="1" Text="Open project file"
-                                           FontSize="12.5" Foreground="{DynamicResource AccentBrush}"
-                                           VerticalAlignment="Center"/>
+                            <Grid Margin="0,0,0,8"><Grid.ColumnDefinitions><ColumnDefinition Width="Auto"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
+                                <Border Style="{StaticResource KbdBadgeStyle}"><TextBlock Text="Ctrl+Y" FontFamily="Cascadia Code, Consolas" FontSize="11" Foreground="{DynamicResource TextBrush}"/></Border>
+                                <TextBlock Grid.Column="1" Text="Redo last action" FontSize="12.5" Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center"/>
                             </Grid>
-                            <Grid Margin="0,0,0,8">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="*"/>
-                                </Grid.ColumnDefinitions>
-                                <Border Style="{StaticResource KbdBadgeStyle}">
-                                    <TextBlock Text="Alt+S" FontFamily="Cascadia Code, Consolas"
-                                               FontSize="11" Foreground="{DynamicResource TextBrush}"/>
-                                </Border>
-                                <TextBlock Grid.Column="1" Text="Open settings"
-                                           FontSize="12.5" Foreground="{DynamicResource AccentBrush}"
-                                           VerticalAlignment="Center"/>
+                            <Grid Margin="0,0,0,8"><Grid.ColumnDefinitions><ColumnDefinition Width="Auto"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
+                                <Border Style="{StaticResource KbdBadgeStyle}"><TextBlock Text="Esc" FontFamily="Cascadia Code, Consolas" FontSize="11" Foreground="{DynamicResource TextBrush}"/></Border>
+                                <TextBlock Grid.Column="1" Text="Deselect mesh / close dialog" FontSize="12.5" Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center"/>
                             </Grid>
-                            <Grid Margin="0,0,0,8">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="*"/>
-                                </Grid.ColumnDefinitions>
-                                <Border Style="{StaticResource KbdBadgeStyle}">
-                                    <TextBlock Text="Esc" FontFamily="Cascadia Code, Consolas"
-                                               FontSize="11" Foreground="{DynamicResource TextBrush}"/>
-                                </Border>
-                                <TextBlock Grid.Column="1" Text="Close dialog / exit view"
-                                           FontSize="12.5" Foreground="{DynamicResource AccentBrush}"
-                                           VerticalAlignment="Center"/>
+                            <Grid Margin="0,0,0,8"><Grid.ColumnDefinitions><ColumnDefinition Width="Auto"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
+                                <Border Style="{StaticResource KbdBadgeStyle}"><TextBlock Text="Alt+O" FontFamily="Cascadia Code, Consolas" FontSize="11" Foreground="{DynamicResource TextBrush}"/></Border>
+                                <TextBlock Grid.Column="1" Text="Open project file" FontSize="12.5" Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center"/>
                             </Grid>
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="*"/>
-                                </Grid.ColumnDefinitions>
-                                <Border Style="{StaticResource KbdBadgeStyle}">
-                                    <TextBlock Text="Alt+F4" FontFamily="Cascadia Code, Consolas"
-                                               FontSize="11" Foreground="{DynamicResource TextBrush}"/>
-                                </Border>
-                                <TextBlock Grid.Column="1" Text="Close application"
-                                           FontSize="12.5" Foreground="{DynamicResource AccentBrush}"
-                                           VerticalAlignment="Center"/>
+                            <Grid Margin="0,0,0,8"><Grid.ColumnDefinitions><ColumnDefinition Width="Auto"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
+                                <Border Style="{StaticResource KbdBadgeStyle}"><TextBlock Text="Alt+S" FontFamily="Cascadia Code, Consolas" FontSize="11" Foreground="{DynamicResource TextBrush}"/></Border>
+                                <TextBlock Grid.Column="1" Text="Open settings" FontSize="12.5" Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center"/>
+                            </Grid>
+                            <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="Auto"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
+                                <Border Style="{StaticResource KbdBadgeStyle}"><TextBlock Text="Alt+F4" FontFamily="Cascadia Code, Consolas" FontSize="11" Foreground="{DynamicResource TextBrush}"/></Border>
+                                <TextBlock Grid.Column="1" Text="Close application" FontSize="12.5" Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center"/>
                             </Grid>
                         </StackPanel>
-
                         <!-- Right column -->
                         <StackPanel>
-                            <Grid Margin="0,0,0,8">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="*"/>
-                                </Grid.ColumnDefinitions>
-                                <Border Style="{StaticResource KbdBadgeStyle}">
-                                    <TextBlock Text="W / S" FontFamily="Cascadia Code, Consolas"
-                                               FontSize="11" Foreground="{DynamicResource TextBrush}"/>
-                                </Border>
-                                <TextBlock Grid.Column="1" Text="Move forward / backward"
-                                           FontSize="12.5" Foreground="{DynamicResource AccentBrush}"
-                                           VerticalAlignment="Center"/>
+                            <Grid Margin="0,0,0,8"><Grid.ColumnDefinitions><ColumnDefinition Width="Auto"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
+                                <Border Style="{StaticResource KbdBadgeStyle}"><TextBlock Text="W / S" FontFamily="Cascadia Code, Consolas" FontSize="11" Foreground="{DynamicResource TextBrush}"/></Border>
+                                <TextBlock Grid.Column="1" Text="Move camera forward / back" FontSize="12.5" Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center"/>
                             </Grid>
-                            <Grid Margin="0,0,0,8">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="*"/>
-                                </Grid.ColumnDefinitions>
-                                <Border Style="{StaticResource KbdBadgeStyle}">
-                                    <TextBlock Text="A / D" FontFamily="Cascadia Code, Consolas"
-                                               FontSize="11" Foreground="{DynamicResource TextBrush}"/>
-                                </Border>
-                                <TextBlock Grid.Column="1" Text="Move camera left / right"
-                                           FontSize="12.5" Foreground="{DynamicResource AccentBrush}"
-                                           VerticalAlignment="Center"/>
+                            <Grid Margin="0,0,0,8"><Grid.ColumnDefinitions><ColumnDefinition Width="Auto"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
+                                <Border Style="{StaticResource KbdBadgeStyle}"><TextBlock Text="A / D" FontFamily="Cascadia Code, Consolas" FontSize="11" Foreground="{DynamicResource TextBrush}"/></Border>
+                                <TextBlock Grid.Column="1" Text="Move camera left / right" FontSize="12.5" Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center"/>
                             </Grid>
-                            <Grid Margin="0,0,0,8">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="*"/>
-                                </Grid.ColumnDefinitions>
-                                <Border Style="{StaticResource KbdBadgeStyle}">
-                                    <TextBlock Text="Space" FontFamily="Cascadia Code, Consolas"
-                                               FontSize="11" Foreground="{DynamicResource TextBrush}"/>
-                                </Border>
-                                <TextBlock Grid.Column="1" Text="Move camera up"
-                                           FontSize="12.5" Foreground="{DynamicResource AccentBrush}"
-                                           VerticalAlignment="Center"/>
+                            <Grid Margin="0,0,0,8"><Grid.ColumnDefinitions><ColumnDefinition Width="Auto"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
+                                <Border Style="{StaticResource KbdBadgeStyle}"><TextBlock Text="Space" FontFamily="Cascadia Code, Consolas" FontSize="11" Foreground="{DynamicResource TextBrush}"/></Border>
+                                <TextBlock Grid.Column="1" Text="Move camera up" FontSize="12.5" Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center"/>
                             </Grid>
-                            <Grid Margin="0,0,0,8">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="*"/>
-                                </Grid.ColumnDefinitions>
-                                <Border Style="{StaticResource KbdBadgeStyle}">
-                                    <TextBlock Text="L-Shift" FontFamily="Cascadia Code, Consolas"
-                                               FontSize="11" Foreground="{DynamicResource TextBrush}"/>
-                                </Border>
-                                <TextBlock Grid.Column="1" Text="Move camera down"
-                                           FontSize="12.5" Foreground="{DynamicResource AccentBrush}"
-                                           VerticalAlignment="Center"/>
+                            <Grid Margin="0,0,0,8"><Grid.ColumnDefinitions><ColumnDefinition Width="Auto"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
+                                <Border Style="{StaticResource KbdBadgeStyle}"><TextBlock Text="L-Shift" FontFamily="Cascadia Code, Consolas" FontSize="11" Foreground="{DynamicResource TextBrush}"/></Border>
+                                <TextBlock Grid.Column="1" Text="Move camera down" FontSize="12.5" Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center"/>
                             </Grid>
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="*"/>
-                                </Grid.ColumnDefinitions>
-                                <Border Style="{StaticResource KbdBadgeStyle}">
-                                    <TextBlock Text="Q / E" FontFamily="Cascadia Code, Consolas"
-                                               FontSize="11" Foreground="{DynamicResource TextBrush}"/>
-                                </Border>
-                                <TextBlock Grid.Column="1" Text="Roll camera left / right"
-                                           FontSize="12.5" Foreground="{DynamicResource AccentBrush}"
-                                           VerticalAlignment="Center"/>
+                            <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="Auto"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
+                                <Border Style="{StaticResource KbdBadgeStyle}"><TextBlock Text="Q / E" FontFamily="Cascadia Code, Consolas" FontSize="11" Foreground="{DynamicResource TextBrush}"/></Border>
+                                <TextBlock Grid.Column="1" Text="Roll camera left / right" FontSize="12.5" Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center"/>
                             </Grid>
                         </StackPanel>
                     </UniformGrid>
@@ -275,6 +187,68 @@
                             <TextBlock Grid.Column="1" Text="Hold + drag — pan camera"
                                        FontSize="12.5" Foreground="{DynamicResource AccentBrush}"
                                        VerticalAlignment="Center"/>
+                        </Grid>
+                    </StackPanel>
+                </Border>
+
+                <!-- Toolbar Modes -->
+                <TextBlock Text="TOOLBAR MODES"
+                           Style="{StaticResource SectionLabelStyle}"
+                           Margin="0,6,0,8"/>
+                <Border Style="{StaticResource CardBorderStyle}">
+                    <StackPanel>
+                        <Grid Margin="0,0,0,7"><Grid.ColumnDefinitions><ColumnDefinition Width="110"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
+                            <Border Style="{StaticResource KbdBadgeStyle}" MinWidth="90"><TextBlock Text="⊙ Select" FontFamily="Cascadia Code, Consolas" FontSize="11" Foreground="{DynamicResource TextBrush}"/></Border>
+                            <TextBlock Grid.Column="1" Text="Left-click a mesh to select it" FontSize="12.5" Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center"/>
+                        </Grid>
+                        <Grid Margin="0,0,0,7"><Grid.ColumnDefinitions><ColumnDefinition Width="110"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
+                            <Border Style="{StaticResource KbdBadgeStyle}" MinWidth="90"><TextBlock Text="✦ Move" FontFamily="Cascadia Code, Consolas" FontSize="11" Foreground="{DynamicResource TextBrush}"/></Border>
+                            <TextBlock Grid.Column="1" Text="Drag axis arrows to translate, or drag body for free XZ move" FontSize="12.5" Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                        </Grid>
+                        <Grid Margin="0,0,0,7"><Grid.ColumnDefinitions><ColumnDefinition Width="110"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
+                            <Border Style="{StaticResource KbdBadgeStyle}" MinWidth="90"><TextBlock Text="↺ Rotate" FontFamily="Cascadia Code, Consolas" FontSize="11" Foreground="{DynamicResource TextBrush}"/></Border>
+                            <TextBlock Grid.Column="1" Text="Drag a colored ring to rotate on that axis, or drag the mesh body to spin freely" FontSize="12.5" Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                        </Grid>
+                        <Grid Margin="0,0,0,7"><Grid.ColumnDefinitions><ColumnDefinition Width="110"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
+                            <Border Style="{StaticResource KbdBadgeStyle}" MinWidth="90"><TextBlock Text="⦿ Gimbal" FontFamily="Cascadia Code, Consolas" FontSize="11" Foreground="{DynamicResource TextBrush}"/></Border>
+                            <TextBlock Grid.Column="1" Text="Combined mode — drag rings to rotate, drag arrows to translate, drag body for free move" FontSize="12.5" Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                        </Grid>
+                        <Grid Margin="0,0,0,7"><Grid.ColumnDefinitions><ColumnDefinition Width="110"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
+                            <Border Style="{StaticResource KbdBadgeStyle}" MinWidth="90"><TextBlock Text="✕ Delete" FontFamily="Cascadia Code, Consolas" FontSize="11" Foreground="{DynamicResource TextBrush}"/></Border>
+                            <TextBlock Grid.Column="1" Text="Click a mesh to remove it from the scene (undoable)" FontSize="12.5" Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                        </Grid>
+                        <Grid Margin="0,0,0,7"><Grid.ColumnDefinitions><ColumnDefinition Width="110"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
+                            <Border Style="{StaticResource KbdBadgeStyle}" MinWidth="90"><TextBlock Text="✕ Deselect" FontFamily="Cascadia Code, Consolas" FontSize="11" Foreground="{DynamicResource TextBrush}"/></Border>
+                            <TextBlock Grid.Column="1" Text="Clear the current selection and hide the gizmo. Also triggered by pressing Esc." FontSize="12.5" Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                        </Grid>
+                        <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="110"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
+                            <Border Style="{StaticResource KbdBadgeStyle}" MinWidth="90"><TextBlock Text="⌂ Snap Back" FontFamily="Cascadia Code, Consolas" FontSize="11" Foreground="{DynamicResource TextBrush}"/></Border>
+                            <TextBlock Grid.Column="1" Text="Resets the selected mesh to its original import position and rotation (undoable)" FontSize="12.5" Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                        </Grid>
+                    </StackPanel>
+                </Border>
+
+                <!-- Tools Panel Features -->
+                <TextBlock Text="TOOLS PANEL"
+                           Style="{StaticResource SectionLabelStyle}"
+                           Margin="0,6,0,8"/>
+                <Border Style="{StaticResource CardBorderStyle}">
+                    <StackPanel>
+                        <Grid Margin="0,0,0,7"><Grid.ColumnDefinitions><ColumnDefinition Width="160"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
+                            <Border Style="{StaticResource KbdBadgeStyle}" MinWidth="140"><TextBlock Text="Scale &amp; Information" FontFamily="Cascadia Code, Consolas" FontSize="11" Foreground="{DynamicResource TextBrush}"/></Border>
+                            <TextBlock Grid.Column="1" Text="Click to expand — shows mesh name, vertex count, dimensions and XYZ position in your chosen unit (m, cm, mm, in, ft, mi), plus Scale and Move By controls" FontSize="12.5" Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                        </Grid>
+                        <Grid Margin="0,0,0,7"><Grid.ColumnDefinitions><ColumnDefinition Width="160"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
+                            <Border Style="{StaticResource KbdBadgeStyle}" MinWidth="140"><TextBlock Text="Precise Rotate" FontFamily="Cascadia Code, Consolas" FontSize="11" Foreground="{DynamicResource TextBrush}"/></Border>
+                            <TextBlock Grid.Column="1" Text="Type exact degrees for X, Y and Z axes and click Apply Rotation. Supports negative values. Fully undoable." FontSize="12.5" Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                        </Grid>
+                        <Grid Margin="0,0,0,7"><Grid.ColumnDefinitions><ColumnDefinition Width="160"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
+                            <Border Style="{StaticResource KbdBadgeStyle}" MinWidth="140"><TextBlock Text="Replace Mesh" FontFamily="Cascadia Code, Consolas" FontSize="11" Foreground="{DynamicResource TextBrush}"/></Border>
+                            <TextBlock Grid.Column="1" Text="Replaces the selected mesh with a bounding Cylinder, Cube/Prism, or Wedge of the same dimensions" FontSize="12.5" Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                        </Grid>
+                        <Grid><Grid.ColumnDefinitions><ColumnDefinition Width="160"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
+                            <Border Style="{StaticResource KbdBadgeStyle}" MinWidth="140"><TextBlock Text="Small Mesh Threshold" FontFamily="Cascadia Code, Consolas" FontSize="11" Foreground="{DynamicResource TextBrush}"/></Border>
+                            <TextBlock Grid.Column="1" Text="Slider that hides meshes below a size percentage. Drag left to show all, right to filter out small parts. Does not delete meshes." FontSize="12.5" Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center" TextWrapping="Wrap"/>
                         </Grid>
                     </StackPanel>
                 </Border>

--- a/UnBox3D/Views/MainWindow.xaml
+++ b/UnBox3D/Views/MainWindow.xaml
@@ -39,8 +39,7 @@
         <MenuItem Header="Redo" Command="{Binding RedoActionCommand}" InputGestureText="Ctrl+Y" Style="{StaticResource SubMenuItemStyle}"/>
         </MenuItem>
         <MenuItem Header="View">
-        <MenuItem Header="Reset View"       Command="{Binding ResetViewCommand}"           Style="{StaticResource SubMenuItemStyle}"/>
-        <MenuItem Header="Toggle Hierarchy" Command="{Binding ToggleHierarchyCommand}"     Style="{StaticResource SubMenuItemStyle}"/>
+        <MenuItem Header="Reset View" Command="{Binding ResetViewCommand}" Style="{StaticResource SubMenuItemStyle}"/>
         </MenuItem>
         <MenuItem Header="Tools">
         <MenuItem Header="Replace Scene with Bounding Boxes" Command="{Binding ReplaceSceneWithBoundingBoxesCommand}" Style="{StaticResource SubMenuItemStyle}"/>
@@ -206,15 +205,33 @@
                 <Border Width="1" Height="22" Background="{DynamicResource BorderBrushLight}"
                         Margin="6,0" VerticalAlignment="Center"/>
 
-                <!-- Hierarchy toggle -->
-                <Button ToolTip="Toggle mesh hierarchy  (View → Toggle Hierarchy)"
-                        Command="{Binding ToggleHierarchyCommand}"
+                <!-- Deselect -->
+                <Button ToolTip="Deselect the current mesh and hide the gizmo"
+                        Command="{Binding DeselectCommand}"
+                        IsEnabled="{Binding HasSelectedMesh}"
                         Style="{StaticResource ToolbarButtonStyle}">
                     <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="&#x2630;" FontSize="13" Margin="0,0,5,0"
+                        <TextBlock Text="&#x2715;" FontSize="13" Margin="0,0,5,0"
                                    Foreground="{DynamicResource AccentBrush}"
                                    VerticalAlignment="Center"/>
-                        <TextBlock Text="Hierarchy" VerticalAlignment="Center"/>
+                        <TextBlock Text="Deselect" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Button>
+
+                <!-- Divider -->
+                <Border Width="1" Height="22" Background="{DynamicResource BorderBrushLight}"
+                        Margin="6,0" VerticalAlignment="Center"/>
+
+                <!-- Snap Back (toolbar shortcut for selected mesh) -->
+                <Button ToolTip="Snap selected mesh back to its original import position"
+                        Command="{Binding SnapBackSelectedCommand}"
+                        IsEnabled="{Binding HasSelectedMesh}"
+                        Style="{StaticResource ToolbarButtonStyle}">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="&#x2302;" FontSize="14" Margin="0,0,5,0"
+                                   Foreground="{DynamicResource AccentBrush}"
+                                   VerticalAlignment="Center"/>
+                        <TextBlock Text="Snap Back" VerticalAlignment="Center"/>
                     </StackPanel>
                 </Button>
 
@@ -406,16 +423,40 @@
                                     </StackPanel>
                                     <!-- Action buttons -->
                                     <StackPanel Orientation="Horizontal" Margin="0,0,0,2">
-                                        <Button Content="Export"
-                                                FontSize="11" Padding="8,3"
+                                        <Button FontSize="11" Padding="8,3"
                                                 Command="{Binding DataContext.ExportMeshCommand, RelativeSource={RelativeSource AncestorType=TreeView}}"
-                                                CommandParameter="{Binding SourceMesh}"/>
-                                        <Button Content="Delete"
-                                                FontSize="11" Padding="8,3"
+                                                CommandParameter="{Binding SourceMesh}"
+                                                ToolTip="Export this mesh as OBJ">
+                                            <StackPanel Orientation="Horizontal">
+                                                <TextBlock Text="&#x2197;" FontSize="11" Margin="0,0,4,0"
+                                                           Foreground="{DynamicResource AccentBrush}"
+                                                           VerticalAlignment="Center"/>
+                                                <TextBlock Text="Export" VerticalAlignment="Center"/>
+                                            </StackPanel>
+                                        </Button>
+                                        <Button FontSize="11" Padding="8,3" Margin="5,0,0,0"
+                                                ToolTip="Snap this mesh back to where it was when imported"
+                                                Command="{Binding DataContext.SnapBackMeshCommand, RelativeSource={RelativeSource AncestorType=TreeView}}"
+                                                CommandParameter="{Binding SourceMesh}">
+                                            <StackPanel Orientation="Horizontal">
+                                                <TextBlock Text="&#x2302;" FontSize="11" Margin="0,0,3,0"
+                                                           Foreground="{DynamicResource AccentBrush}"
+                                                           VerticalAlignment="Center"/>
+                                                <TextBlock Text="Snap Back" VerticalAlignment="Center"/>
+                                            </StackPanel>
+                                        </Button>
+                                        <Button FontSize="11" Padding="8,3"
                                                 Margin="5,0,0,0"
                                                 Style="{StaticResource DangerButtonStyle}"
                                                 Command="{Binding DataContext.DeleteMeshCommand, RelativeSource={RelativeSource AncestorType=TreeView}}"
-                                                CommandParameter="{Binding SourceMesh}"/>
+                                                CommandParameter="{Binding SourceMesh}"
+                                                ToolTip="Delete this mesh from the scene">
+                                            <StackPanel Orientation="Horizontal">
+                                                <TextBlock Text="&#x2715;" FontSize="11" Margin="0,0,4,0"
+                                                           VerticalAlignment="Center"/>
+                                                <TextBlock Text="Delete" VerticalAlignment="Center"/>
+                                            </StackPanel>
+                                        </Button>
                                     </StackPanel>
                                 </StackPanel>
                             </DataTemplate>
@@ -473,6 +514,284 @@
                                   Padding="12,10,12,10">
                         <StackPanel>
 
+                            <!-- ══ Scale & Information toggle button ══ -->
+                            <Button HorizontalAlignment="Stretch"
+                                    IsEnabled="{Binding HasSelectedMesh}"
+                                    Command="{Binding ToggleScaleInfoPanelCommand}"
+                                    ToolTip="View mesh info, position, and scale options"
+                                    Margin="0,0,0,4">
+                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                    <TextBlock FontSize="10" Margin="0,0,7,0" VerticalAlignment="Center"
+                                               Foreground="{DynamicResource AccentBrush}">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Text" Value="▶"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsScaleInfoPanelOpen}" Value="True">
+                                                        <Setter Property="Text" Value="▼"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                    <TextBlock Text="Scale &amp; Information" FontWeight="SemiBold"
+                                               VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </Button>
+
+                            <!-- Animated expandable panel -->
+                            <Border ClipToBounds="True" Margin="0,0,0,14">
+                                <Border.Style>
+                                    <Style TargetType="Border">
+                                        <Setter Property="MaxHeight" Value="0"/>
+                                        <Setter Property="Opacity"   Value="0"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsScaleInfoPanelOpen}" Value="True">
+                                                <DataTrigger.EnterActions>
+                                                    <BeginStoryboard>
+                                                        <Storyboard>
+                                                            <DoubleAnimation Storyboard.TargetProperty="MaxHeight"
+                                                                             To="1200" Duration="0:0:0.35">
+                                                                <DoubleAnimation.EasingFunction>
+                                                                    <CubicEase EasingMode="EaseOut"/>
+                                                                </DoubleAnimation.EasingFunction>
+                                                            </DoubleAnimation>
+                                                            <DoubleAnimation Storyboard.TargetProperty="Opacity"
+                                                                             To="1" Duration="0:0:0.28"/>
+                                                        </Storyboard>
+                                                    </BeginStoryboard>
+                                                </DataTrigger.EnterActions>
+                                                <DataTrigger.ExitActions>
+                                                    <BeginStoryboard>
+                                                        <Storyboard>
+                                                            <DoubleAnimation Storyboard.TargetProperty="MaxHeight"
+                                                                             To="0" Duration="0:0:0.25">
+                                                                <DoubleAnimation.EasingFunction>
+                                                                    <CubicEase EasingMode="EaseIn"/>
+                                                                </DoubleAnimation.EasingFunction>
+                                                            </DoubleAnimation>
+                                                            <DoubleAnimation Storyboard.TargetProperty="Opacity"
+                                                                             To="0" Duration="0:0:0.2"/>
+                                                        </Storyboard>
+                                                    </BeginStoryboard>
+                                                </DataTrigger.ExitActions>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Border.Style>
+
+                                <Border Background="{DynamicResource CardBrush}"
+                                        BorderBrush="{DynamicResource HighlightBrush}"
+                                        BorderThickness="1" CornerRadius="6"
+                                        Padding="10,10">
+                                    <StackPanel>
+
+                                        <!-- Mesh name + vertex count -->
+                                        <TextBlock Text="{Binding SelectedMeshInfoName}"
+                                                   FontSize="12" FontWeight="SemiBold"
+                                                   Foreground="{DynamicResource TextBrush}"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   Margin="0,0,0,2"/>
+                                        <TextBlock Text="{Binding SelectedMeshInfoVerts}"
+                                                   FontSize="10.5"
+                                                   Foreground="{DynamicResource AccentBrush}"
+                                                   Margin="0,0,0,8"/>
+
+                                        <!-- Unit selector -->
+                                        <TextBlock Text="DISPLAY UNIT"
+                                                   FontSize="9" FontWeight="SemiBold"
+                                                   Foreground="{DynamicResource AccentBrush}"
+                                                   Margin="0,0,0,4"/>
+                                        <ComboBox ItemsSource="{x:Static viewmodels:MainViewModel.UnitOptions}"
+                                                  SelectedItem="{Binding SelectedUnit, Mode=TwoWay}"
+                                                  Margin="0,0,0,10"/>
+
+                                        <!-- Divider -->
+                                        <Border Height="1" Background="{DynamicResource BorderBrushLight}" Margin="0,0,0,8"/>
+
+                                        <!-- Dimensions -->
+                                        <TextBlock Text="DIMENSIONS"
+                                                   FontSize="9" FontWeight="SemiBold"
+                                                   Foreground="{DynamicResource AccentBrush}"
+                                                   Margin="0,0,0,3"/>
+                                        <TextBlock Text="{Binding FormattedDims}"
+                                                   FontFamily="Cascadia Code, Consolas"
+                                                   FontSize="10.5"
+                                                   Foreground="{DynamicResource HighlightBrush}"
+                                                   Margin="0,0,0,8"/>
+
+                                        <!-- Position -->
+                                        <TextBlock Text="POSITION"
+                                                   FontSize="9" FontWeight="SemiBold"
+                                                   Foreground="{DynamicResource AccentBrush}"
+                                                   Margin="0,0,0,3"/>
+                                        <TextBlock Text="{Binding FormattedCoords}"
+                                                   FontFamily="Cascadia Code, Consolas"
+                                                   FontSize="10.5"
+                                                   Foreground="{DynamicResource HighlightBrush}"
+                                                   Margin="0,0,0,8"/>
+
+                                        <!-- Divider -->
+                                        <Border Height="1" Background="{DynamicResource BorderBrushLight}" Margin="0,0,0,8"/>
+
+                                        <!-- Scale ───────────────────────────────────────── -->
+                                        <TextBlock Text="SCALE"
+                                                   FontSize="9" FontWeight="SemiBold"
+                                                   Foreground="{DynamicResource AccentBrush}"
+                                                   Margin="0,0,0,5"/>
+
+                                        <!-- Axis toggles -->
+                                        <TextBlock Text="AXES"
+                                                   FontSize="9" FontWeight="SemiBold"
+                                                   Foreground="{DynamicResource AccentBrush}"
+                                                   Margin="0,0,0,4"/>
+                                        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                                            <ToggleButton IsChecked="{Binding ScaleAxisX, Mode=TwoWay}"
+                                                          Width="40" Height="28" Margin="0,0,6,0"
+                                                          ToolTip="Include X axis in scale">
+                                                <TextBlock Text="X" FontWeight="SemiBold" Foreground="#EF4444"/>
+                                            </ToggleButton>
+                                            <ToggleButton IsChecked="{Binding ScaleAxisY, Mode=TwoWay}"
+                                                          Width="40" Height="28" Margin="0,0,6,0"
+                                                          ToolTip="Include Y axis in scale">
+                                                <TextBlock Text="Y" FontWeight="SemiBold" Foreground="#22C55E"/>
+                                            </ToggleButton>
+                                            <ToggleButton IsChecked="{Binding ScaleAxisZ, Mode=TwoWay}"
+                                                          Width="40" Height="28"
+                                                          ToolTip="Include Z axis in scale">
+                                                <TextBlock Text="Z" FontWeight="SemiBold" Foreground="#3B82F6"/>
+                                            </ToggleButton>
+                                        </StackPanel>
+
+                                        <!-- Factor -->
+                                        <TextBlock Text="FACTOR"
+                                                   FontSize="9" FontWeight="SemiBold"
+                                                   Foreground="{DynamicResource AccentBrush}"
+                                                   Margin="0,0,0,4"/>
+                                        <TextBox Text="{Binding ScaleValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                 PreviewTextInput="AngleTextBox_PreviewTextInput"
+                                                 PreviewKeyDown="NumericTextBox_PreviewKeyDown"
+                                                 ToolTip="Scale multiplier (e.g. 2 = double, 0.5 = halve)"
+                                                 Margin="0,0,0,8"/>
+
+                                        <!-- Current size in selected unit -->
+                                        <TextBlock Text="CURRENT SIZE"
+                                                   FontSize="9" FontWeight="SemiBold"
+                                                   Foreground="{DynamicResource AccentBrush}"
+                                                   Margin="0,0,0,3"/>
+                                        <TextBlock Text="{Binding FormattedDims}"
+                                                   FontFamily="Cascadia Code, Consolas"
+                                                   FontSize="10.5"
+                                                   Foreground="{DynamicResource HighlightBrush}"
+                                                   Margin="0,0,0,8"/>
+
+                                        <!-- After scale preview -->
+                                        <TextBlock Text="AFTER SCALE"
+                                                   FontSize="9" FontWeight="SemiBold"
+                                                   Foreground="{DynamicResource AccentBrush}"
+                                                   Margin="0,0,0,3"/>
+                                        <TextBlock Text="{Binding FormattedPreviewDims}"
+                                                   FontFamily="Cascadia Code, Consolas"
+                                                   FontSize="10.5"
+                                                   Foreground="#22C55E"
+                                                   Margin="0,0,0,10"/>
+
+                                        <Button Content="Apply Scale"
+                                                HorizontalAlignment="Stretch"
+                                                Command="{Binding ApplyScaleCommand}"
+                                                ToolTip="Scale the selected mesh on the toggled axes (undoable)"/>
+
+                                        <!-- Divider -->
+                                        <Border Height="1" Background="{DynamicResource BorderBrushLight}" Margin="0,10,0,8"/>
+
+                                        <!-- Precise Move ──────────────────────────── -->
+                                        <TextBlock Text="MOVE BY"
+                                                   FontSize="9" FontWeight="SemiBold"
+                                                   Foreground="{DynamicResource AccentBrush}"
+                                                   Margin="0,0,0,5"/>
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="*"/>
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock Grid.Column="0" Text="X" FontSize="11" FontWeight="SemiBold"
+                                                       Foreground="#EF4444" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                            <TextBox Grid.Column="1"
+                                                     Text="{Binding PreciseMoveX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                     PreviewTextInput="AngleTextBox_PreviewTextInput"
+                                                     PreviewKeyDown="NumericTextBox_PreviewKeyDown"/>
+                                            <TextBlock Grid.Column="2" Text="Y" FontSize="11" FontWeight="SemiBold"
+                                                       Foreground="#22C55E" VerticalAlignment="Center" Margin="7,0,5,0"/>
+                                            <TextBox Grid.Column="3"
+                                                     Text="{Binding PreciseMoveY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                     PreviewTextInput="AngleTextBox_PreviewTextInput"
+                                                     PreviewKeyDown="NumericTextBox_PreviewKeyDown"/>
+                                            <TextBlock Grid.Column="4" Text="Z" FontSize="11" FontWeight="SemiBold"
+                                                       Foreground="#3B82F6" VerticalAlignment="Center" Margin="7,0,5,0"/>
+                                            <TextBox Grid.Column="5"
+                                                     Text="{Binding PreciseMoveZ, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                     PreviewTextInput="AngleTextBox_PreviewTextInput"
+                                                     PreviewKeyDown="NumericTextBox_PreviewKeyDown"/>
+                                        </Grid>
+                                        <Button Content="Apply Move"
+                                                HorizontalAlignment="Stretch"
+                                                Command="{Binding ApplyPreciseMoveCommand}"
+                                                ToolTip="Translate the mesh by the typed XYZ delta (undoable)"
+                                                Margin="0,7,0,0"/>
+
+                                        <!-- Divider -->
+                                        <Border Height="1" Background="{DynamicResource BorderBrushLight}" Margin="0,10,0,8"/>
+
+                                        <!-- Precise Rotate ─────────────────────────── -->
+                                        <TextBlock Text="ROTATE BY"
+                                                   FontSize="9" FontWeight="SemiBold"
+                                                   Foreground="{DynamicResource AccentBrush}"
+                                                   Margin="0,0,0,5"/>
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="*"/>
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock Grid.Column="0" Text="X" FontSize="11" FontWeight="SemiBold"
+                                                       Foreground="#EF4444" VerticalAlignment="Center" Margin="0,0,5,0"
+                                                       ToolTip="Degrees around X axis"/>
+                                            <TextBox Grid.Column="1"
+                                                     Text="{Binding PreciseRotateX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                     PreviewTextInput="AngleTextBox_PreviewTextInput"
+                                                     PreviewKeyDown="NumericTextBox_PreviewKeyDown"/>
+                                            <TextBlock Grid.Column="2" Text="Y" FontSize="11" FontWeight="SemiBold"
+                                                       Foreground="#22C55E" VerticalAlignment="Center" Margin="7,0,5,0"
+                                                       ToolTip="Degrees around Y axis"/>
+                                            <TextBox Grid.Column="3"
+                                                     Text="{Binding PreciseRotateY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                     PreviewTextInput="AngleTextBox_PreviewTextInput"
+                                                     PreviewKeyDown="NumericTextBox_PreviewKeyDown"/>
+                                            <TextBlock Grid.Column="4" Text="Z" FontSize="11" FontWeight="SemiBold"
+                                                       Foreground="#3B82F6" VerticalAlignment="Center" Margin="7,0,5,0"
+                                                       ToolTip="Degrees around Z axis"/>
+                                            <TextBox Grid.Column="5"
+                                                     Text="{Binding PreciseRotateZ, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                     PreviewTextInput="AngleTextBox_PreviewTextInput"
+                                                     PreviewKeyDown="NumericTextBox_PreviewKeyDown"/>
+                                        </Grid>
+                                        <Button Content="Apply Rotation"
+                                                HorizontalAlignment="Stretch"
+                                                Command="{Binding ApplyPreciseRotateCommand}"
+                                                ToolTip="Apply the typed rotation to the selected mesh (undoable)"
+                                                Margin="0,7,0,0"/>
+
+                                    </StackPanel>
+                                </Border>
+                            </Border>
+
                             <!-- Small Mesh Threshold -->
                             <TextBlock Text="SMALL MESH THRESHOLD"
                                        Style="{StaticResource SectionLabelStyle}"/>
@@ -527,7 +846,9 @@
                                        Style="{StaticResource SectionLabelStyle}"/>
                             <StackPanel Margin="0,0,0,16">
                                 <Button HorizontalAlignment="Stretch" Margin="0,0,0,6"
-                                        Command="{Binding ReplaceWithCylinderClickCommand}">
+                                        Command="{Binding ReplaceWithCylinderClickCommand}"
+                                        IsEnabled="{Binding HasSelectedMesh}"
+                                        ToolTip="Select a mesh first to replace it">
                                     <StackPanel Orientation="Horizontal">
                                         <TextBlock Text="&#x25D4;" FontSize="13" Margin="0,0,8,0"
                                                    Foreground="{DynamicResource HighlightBrush}"
@@ -536,7 +857,9 @@
                                     </StackPanel>
                                 </Button>
                                 <Button HorizontalAlignment="Stretch" Margin="0,0,0,6"
-                                        Command="{Binding ReplaceWithCubeClickCommand}">
+                                        Command="{Binding ReplaceWithCubeClickCommand}"
+                                        IsEnabled="{Binding HasSelectedMesh}"
+                                        ToolTip="Select a mesh first to replace it">
                                     <StackPanel Orientation="Horizontal">
                                         <TextBlock Text="&#x25A1;" FontSize="13" Margin="0,0,8,0"
                                                    Foreground="{DynamicResource HighlightBrush}"
@@ -545,7 +868,9 @@
                                     </StackPanel>
                                 </Button>
                                 <Button HorizontalAlignment="Stretch"
-                                        Command="{Binding ReplaceWithWedgeClickCommand}">
+                                        Command="{Binding ReplaceWithWedgeClickCommand}"
+                                        IsEnabled="{Binding HasSelectedMesh}"
+                                        ToolTip="Select a mesh first to replace it">
                                     <StackPanel Orientation="Horizontal">
                                         <TextBlock Text="&#x25B7;" FontSize="13" Margin="0,0,8,0"
                                                    Foreground="{DynamicResource HighlightBrush}"

--- a/UnBox3D/Views/MainWindow.xaml.cs
+++ b/UnBox3D/Views/MainWindow.xaml.cs
@@ -59,15 +59,19 @@ namespace UnBox3D.Views
             // Subscribe to toast notifications
             ToastService.ToastRequested += ShowToast;
 
-            // Keyboard shortcuts for undo / redo
+            // Keyboard shortcuts for undo / redo / deselect
             var undoGesture = new KeyBinding(
                 new RelayCommandAdapter(() => VM?.UndoActionCommand?.Execute(null)),
                 Key.Z, ModifierKeys.Control);
             var redoGesture = new KeyBinding(
                 new RelayCommandAdapter(() => VM?.RedoActionCommand?.Execute(null)),
                 Key.Y, ModifierKeys.Control);
+            var deselectGesture = new KeyBinding(
+                new RelayCommandAdapter(() => VM?.DeselectCommand?.Execute(null)),
+                Key.Escape, ModifierKeys.None);
             InputBindings.Add(undoGesture);
             InputBindings.Add(redoGesture);
+            InputBindings.Add(deselectGesture);
         }
 
         public void Initialize(IGLControlHost controlHost, ILogger logger, IBlenderInstaller blenderInstaller)
@@ -148,24 +152,7 @@ namespace UnBox3D.Views
                 newVm.PropertyChanged += OnVmPropertyChanged;
         }
 
-        private void OnVmPropertyChanged(object? sender, PropertyChangedEventArgs e)
-        {
-            if (e.PropertyName != nameof(MainViewModel.HierarchyVisible)) return;
-            if (sender is not MainViewModel vm) return;
-
-            Dispatcher.Invoke(() =>
-            {
-                bool show = vm.HierarchyVisible;
-
-                // Stop any running animation so the local value is writable again,
-                // then snap directly - instant and reliable.
-                HierarchyColumn.BeginAnimation(ColumnDefinition.WidthProperty, null);
-                HierarchyColumn.Width = new GridLength(show ? 260 : 0);
-
-                // Also hide the splitter so the 4px gap doesn't linger.
-                HierarchySplitter.Visibility = show ? Visibility.Visible : Visibility.Collapsed;
-            });
-        }
+        private void OnVmPropertyChanged(object? sender, PropertyChangedEventArgs e) { }
 
         private System.Windows.Threading.DispatcherTimer? _toastTimer;
         private System.Windows.Threading.DispatcherTimer? _notifyTimer;
@@ -435,6 +422,36 @@ namespace UnBox3D.Views
                 e.Handled = true;
                 return;
             }
+        }
+
+        /// <summary>
+        /// PreviewTextInput handler for the Precise Rotate angle fields.
+        /// Extends the standard numeric handler to also allow a leading minus sign
+        /// so the user can enter negative degree values (e.g. -90).
+        /// </summary>
+        private void AngleTextBox_PreviewTextInput(object sender, TextCompositionEventArgs e)
+        {
+            if (sender is not TextBox textBox) return;
+
+            char c = e.Text[0];
+
+            // Allow '-' only as the very first character and only once.
+            if (c == '-')
+            {
+                e.Handled = textBox.CaretIndex != 0 || textBox.Text.Contains('-');
+                return;
+            }
+
+            // Allow one decimal point.
+            if (c == '.')
+            {
+                e.Handled = textBox.Text.Contains('.');
+                return;
+            }
+
+            // Allow digits, block everything else.
+            if (!char.IsDigit(c))
+                e.Handled = true;
         }
 
         private void NumericTextBox_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)


### PR DESCRIPTION
Features Added
Snap Back — Resets a selected mesh to its original import position and rotation. Available as a toolbar button, per-mesh button in the hierarchy panel, and is fully undoable via Ctrl+Z. Correctly restores both translation and rotation on undo.
Deselect — Added a Deselect toolbar button and wired Esc as a keyboard shortcut. Clears the selection, removes the highlight color, and hides the gizmo.
Precise Rotation — Type exact degrees for X, Y, Z axes inside the Scale & Information panel and click Apply Rotation. Supports negative values. Fully undoable.
Scale & Information Panel — Collapsible panel (Scale & Information button) in the Tools panel that animates open with a cubic ease. Contains mesh name, vertex count, a unit dropdown (Meters / Centimeters / Millimeters / Inches / Feet / Miles), live dimension readout, live XYZ position readout, scale axis toggles (X/Y/Z), factor input with live "After Scale" preview in the selected unit, Apply Scale, Move By XYZ inputs, Apply Move, and Rotate By XYZ inputs.
Scale Toggle by Axis — X, Y, Z toggle buttons let the user scale on any combination of axes independently.
Highlight Fix — Clicking a mesh while in Move, Rotate, or Gimbal mode now correctly applies the selection highlight color. Previously the OpenGL_MouseDown guard blocked SelectedMeshSummary from being updated when a transform state internally changed its selection.
Replace Mesh buttons greyed out — Cylinder, Cube/Prism, and Wedge buttons are disabled when no mesh is selected via HasSelectedMesh binding.
Small mesh slider selection preserved — Moving the threshold slider no longer clears the active selection. The selected mesh is restored after the collection rebuild if it survived the filter.
Help window updated — Added TOOLBAR MODES and TOOLS PANEL sections covering all new features. Keyboard shortcuts updated to include Ctrl+Z, Ctrl+Y, and Esc.
Dead code removed — ToggleHierarchy command, hierarchyVisible property, and the OnVmPropertyChanged hierarchy animation handler removed.

Files Changed
New Files

UnBox3D/Commands/SnapBackCommand.cs
UnBox3D/Commands/PreciseRotateCommand.cs
UnBox3D/Commands/PreciseMoveCommand.cs
UnBox3D/Commands/ScaleCommand.cs

Modified Files

UnBox3D/Rendering/AppMesh.cs — Added OriginalRenderCenter, SnapToOrigin(), SetTransform(), Scale() to both IAppMesh and AppMesh
UnBox3D/ViewModels/MainViewModel.cs — Added Deselect, SnapBackMesh, SnapBackSelected, ApplyPreciseRotate, ApplyPreciseMove, ApplyScale, ToggleScaleInfoPanel, NotifyStateSelectionChanged, unit system properties, mesh info properties, HasSelectedMesh, removed dead hierarchy code
UnBox3D/Views/MainWindow.xaml — Toolbar updates (Deselect replaces Hierarchy), Scale & Information collapsible panel, Replace Mesh IsEnabled bindings, hierarchy button icons
UnBox3D/Views/MainWindow.xaml.cs — Added Esc KeyBinding for deselect, cleaned up dead OnVmPropertyChanged handler
UnBox3D/Controls/States/MoveState.cs — Added onSelectionChanged callback
UnBox3D/Controls/States/RotateState.cs — Added onSelectionChanged callback
UnBox3D/Controls/States/GimbalState.cs — Added onSelectionChanged callback
UnBox3D/Views/HelpWindow.xaml — Updated keyboard shortcuts, added TOOLBAR MODES and TOOLS PANEL sections