### PR TITLE
Revert "Fix SVG export: mm units, panel tiling, margins, decimal input"

### DIFF
--- a/UnBox3D/Utils/SVGEditor.cs
+++ b/UnBox3D/Utils/SVGEditor.cs
@@ -1,101 +1,31 @@
 ﻿using PdfSharpCore.Drawing;
 using PdfSharpCore.Pdf;
 using Svg;
+using Svg.Transforms;
 using System.Diagnostics;
 using System.IO;
 using System.Drawing.Imaging;    // For ImageFormat
+/* Values are in pixels
+// SOMEONE GET ON THIS
+// Margins don't work? It seems to crop out rather than provide that 2in buffer
+// Needs a proper buffer instead of translating/offsetting the view
+// OPTIMIZATION
+// Rotation and eliminating empty boxes are nice to implement but not urgent 
+*/
 
 namespace UnBox3D.Utils
 {
     public class SVGEditor
     {
-        // Safety cap — refuse to emit more than this many panels from a single export.
-        // Guards against tiny board sizes entered against a huge unfolded net
-        // (e.g. 50 mm boards against a 7 m net => ~20k files).
-        private const int MaxPanels = 64;
+        private const float MmToPx = 3.779527f;
 
         public static void ExportSvgPanels(string inputSvgPath, string outputDirectory, string filename, int pageIndex, float panelWidthMm, float panelHeightMm, float marginMm = 0f)
         {
-            Debug.WriteLine($"panelWidthMM: {panelWidthMm} - panelHeightMM: {panelHeightMm} - marginMM: {marginMm}");
+            Debug.WriteLine($"panelWidthMM: {panelWidthMm} - panelHeightMM: {panelHeightMm}");
 
             Debug.WriteLine($"Processing Page: {pageIndex} - Filename: {inputSvgPath}");
             SvgDocument svgDocument = SvgDocument.Open(inputSvgPath);
 
-            // Blender's paper_model addon emits width/height/viewBox in millimetres.
-            // Stay in mm all the way through so the panel viewBox matches the source coordinate space.
-            //
-            // We tile the drawn content's bounding box rather than the Blender page itself.
-            // The page grows via the retry loop in MainViewModel until the net fits, so it
-            // almost always contains empty whitespace around the net — tiling the page
-            // directly produced sliver panels over that whitespace.
-            var contentBounds = ComputeContentBounds(svgDocument);
-            float netWidthMm, netHeightMm, netOriginXMm, netOriginYMm;
-            if (contentBounds.Width > 0 && contentBounds.Height > 0)
-            {
-                netWidthMm = contentBounds.Width;
-                netHeightMm = contentBounds.Height;
-                netOriginXMm = contentBounds.X;
-                netOriginYMm = contentBounds.Y;
-                Debug.WriteLine($"Content bbox: origin=({netOriginXMm:0.##}, {netOriginYMm:0.##}), size=({netWidthMm:0.##} x {netHeightMm:0.##}) mm");
-            }
-            else
-            {
-                Debug.WriteLine("No drawable content found; falling back to page dimensions.");
-                netWidthMm = svgDocument.Width.Value;
-                netHeightMm = svgDocument.Height.Value;
-                netOriginXMm = 0f;
-                netOriginYMm = 0f;
-            }
-
-            // Whitespace semantics: marginMm is an empty (uncut) border on every side
-            // of the physical board. Content lives only in the inner usable rectangle
-            // (panelWidthMm - 2*marginMm) × (panelHeightMm - 2*marginMm), so the panel
-            // grid tiles the net by usable area, not by physical board size.
-            float usableWidthMm = panelWidthMm - 2 * marginMm;
-            float usableHeightMm = panelHeightMm - 2 * marginMm;
-
-            // Guard: margin too large leaves no room for content. Fall back to untiled
-            // instead of hitting a divide-by-zero or emitting infinite panels.
-            if (usableWidthMm <= 0f || usableHeightMm <= 0f)
-            {
-                string fallbackPath = Path.Combine(outputDirectory, $"{filename}_panel_page{pageIndex}_0_0.svg");
-                Debug.WriteLine($"Margin {marginMm}mm leaves no usable area on a {panelWidthMm}x{panelHeightMm}mm board. Falling back to untiled SVG at {fallbackPath}.");
-
-                try
-                {
-                    if (File.Exists(fallbackPath)) File.Delete(fallbackPath);
-                    File.Move(inputSvgPath, fallbackPath);
-                }
-                catch (Exception ex)
-                {
-                    Debug.WriteLine($"Fallback copy failed: {ex.Message}");
-                }
-                return;
-            }
-
-            int numPanelsX = (int)Math.Ceiling(netWidthMm / usableWidthMm);
-            int numPanelsY = (int)Math.Ceiling(netHeightMm / usableHeightMm);
-
-            // Soft cap — if the requested board size would explode into too many panels,
-            // emit the source SVG untiled instead of silently writing thousands of files.
-            if (numPanelsX * numPanelsY > MaxPanels)
-            {
-                string fallbackPath = Path.Combine(outputDirectory, $"{filename}_panel_page{pageIndex}_0_0.svg");
-                Debug.WriteLine($"Panel count {numPanelsX}x{numPanelsY}={numPanelsX * numPanelsY} exceeds cap of {MaxPanels}. Falling back to a single untiled SVG at {fallbackPath}.");
-
-                try
-                {
-                    if (File.Exists(fallbackPath)) File.Delete(fallbackPath);
-                    File.Move(inputSvgPath, fallbackPath);
-                }
-                catch (Exception ex)
-                {
-                    Debug.WriteLine($"Fallback copy failed: {ex.Message}");
-                }
-                return;
-            }
-
-            // Commit to tiling — the source SVG is consumed by this export.
             try
             {
                 if (File.Exists(inputSvgPath))
@@ -109,87 +39,44 @@ namespace UnBox3D.Utils
                 Debug.WriteLine($"Failed to delete {inputSvgPath}: {ex.Message}");
             }
 
+            float panelWidth = panelWidthMm * MmToPx;
+            float panelHeight = panelHeightMm * MmToPx;
+            float margin = marginMm * MmToPx;
+
+            float svgWidth = svgDocument.Width.Value * MmToPx;
+            float svgHeight = svgDocument.Height.Value * MmToPx;
+
+            int numPanelsX = (int)Math.Ceiling((svgWidth - 2 * margin) / panelWidth);
+            int numPanelsY = (int)Math.Ceiling((svgHeight - 2 * margin) / panelHeight);
+
             for (int x = 0; x < numPanelsX; x++)
             {
                 for (int y = 0; y < numPanelsY; y++)
                 {
-                    // Artboard spans the physical board (panelWidthMm × panelHeightMm).
-                    // ViewBox is anchored so the usable region's top-left net coord
-                    // lands at artboard position (marginMm, marginMm), leaving an
-                    // empty marginMm band on every side.
-                    float usableOriginXMm = netOriginXMm + x * usableWidthMm;
-                    float usableOriginYMm = netOriginYMm + y * usableHeightMm;
-                    float viewBoxXMm = usableOriginXMm - marginMm;
-                    float viewBoxYMm = usableOriginYMm - marginMm;
+                    float xOffset = x * panelWidth + margin;
+                    float yOffset = y * panelHeight + margin;
 
                     SvgDocument panelDoc = new SvgDocument
                     {
-                        Width = new SvgUnit(SvgUnitType.Millimeter, panelWidthMm),
-                        Height = new SvgUnit(SvgUnitType.Millimeter, panelHeightMm),
-                        ViewBox = new SvgViewBox(viewBoxXMm, viewBoxYMm, panelWidthMm, panelHeightMm),
-                        Overflow = SvgOverflow.Hidden
+                        Width = new SvgUnit(panelWidth),
+                        Height = new SvgUnit(panelHeight)
                     };
 
-                    // ClipPath constrains rendered content to the inner usable rectangle.
-                    // Without this, features from neighbouring panels that fall inside
-                    // this panel's viewBox would render into the margin band and end up
-                    // as cuts on the physical board's edge area.
-                    string clipId = $"panelClip_{x}_{y}";
-                    var clipPath = new SvgClipPath { ID = clipId };
-                    clipPath.Children.Add(new SvgRectangle
-                    {
-                        X = new SvgUnit(SvgUnitType.User, usableOriginXMm),
-                        Y = new SvgUnit(SvgUnitType.User, usableOriginYMm),
-                        Width = new SvgUnit(SvgUnitType.User, usableWidthMm),
-                        Height = new SvgUnit(SvgUnitType.User, usableHeightMm)
-                    });
-                    var defs = new SvgDefinitionList();
-                    defs.Children.Add(clipPath);
-                    panelDoc.Children.Add(defs);
-
-                    var contentGroup = new SvgGroup();
-                    contentGroup.CustomAttributes["clip-path"] = $"url(#{clipId})";
                     foreach (SvgElement element in svgDocument.Children)
                     {
                         SvgElement clonedElement = (SvgElement)element.DeepCopy();
-                        contentGroup.Children.Add(clonedElement);
+                        clonedElement.Transforms = new SvgTransformCollection
+                        {
+                            new SvgScale(MmToPx),
+                            new SvgTranslate(-xOffset / MmToPx, -yOffset / MmToPx)
+                        };
+                        panelDoc.Children.Add(clonedElement);
                     }
-                    panelDoc.Children.Add(contentGroup);
 
                     string outputFilePath = Path.Combine(outputDirectory, $"{filename}_panel_page{pageIndex}_{x}_{y}.svg");
                     panelDoc.Write(outputFilePath);
-                    Debug.WriteLine($"Exported panel to {outputFilePath}: viewBox=({viewBoxXMm:0.##}, {viewBoxYMm:0.##}, {panelWidthMm:0.##}, {panelHeightMm:0.##}) mm, usable=({usableOriginXMm:0.##}, {usableOriginYMm:0.##}, {usableWidthMm:0.##}, {usableHeightMm:0.##}) mm");
+                    Debug.WriteLine($"Exported panel to {outputFilePath} with x-offset: {xOffset}, y-offset: {yOffset}");
                 }
-            }
-        }
-
-        // Walk the SVG tree and union the bounding boxes of every drawable leaf
-        // (paths, text, shapes). Containers (groups, the svg root) and non-visual
-        // nodes (style, defs) are skipped because their own .Bounds would either
-        // double-count descendants or be meaningless.
-        private static System.Drawing.RectangleF ComputeContentBounds(SvgElement root)
-        {
-            System.Drawing.RectangleF acc = System.Drawing.RectangleF.Empty;
-            AccumulateBounds(root, ref acc);
-            return acc;
-        }
-
-        private static void AccumulateBounds(SvgElement element, ref System.Drawing.RectangleF acc)
-        {
-            if (element is SvgVisualElement visual
-                && !(element is SvgGroup)
-                && !(element is SvgFragment))
-            {
-                var b = visual.Bounds;
-                if (b.Width > 0 || b.Height > 0)
-                {
-                    acc = acc.IsEmpty ? b : System.Drawing.RectangleF.Union(acc, b);
-                }
-            }
-
-            foreach (var child in element.Children)
-            {
-                AccumulateBounds(child, ref acc);
             }
         }
 

--- a/UnBox3D/ViewModels/MainViewModel.cs
+++ b/UnBox3D/ViewModels/MainViewModel.cs
@@ -53,23 +53,11 @@ namespace UnBox3D.ViewModels
         [ObservableProperty]
         private IAppMesh? selectedMesh;
 
-        // Page dimensions are in METERS — Blender's paper_model addon consumes
-        // output_size_x/y as meters, and SVGEditor receives the same value scaled to mm.
-        // Defaults match the laser cutter's maximum board size (4 m × 8 m). Users can
-        // override in the UI for smaller stock.
         [ObservableProperty]
-        private float pageWidth = 4.0f;
+        private float pageWidth = 25.0f;
 
         [ObservableProperty]
-        private float pageHeight = 8.0f;
-
-        // Whitespace margin in metres on every side of each physical board.
-        // The inner (pageWidth - 2*margin) × (pageHeight - 2*margin) region is the
-        // usable cut area; the margin band around it is empty on the exported panel.
-        // Default 1 m for initial testing of the visible effect; realistic values
-        // are much smaller (centimetres).
-        [ObservableProperty]
-        private float panelMargin = 0.1f;
+        private float pageHeight = 25.0f;
 
         [ObservableProperty]
         private float simplificationRatio = 50f; // represents percentage (10–100)
@@ -209,7 +197,7 @@ namespace UnBox3D.ViewModels
             }
 
             string destinationPath = _fileSystem.CombinePaths(importDirectory, Path.GetFileName(filePath));
-
+            
             try
             {
                 File.Copy(filePath, destinationPath, overwrite: true);
@@ -395,8 +383,6 @@ namespace UnBox3D.ViewModels
 
                 CleanupUnfoldedFolder(outputDirectory);
 
-                // Blender-page dimensions in metres. Grows via the retry loop below when
-                // the unfolded net doesn't fit.
                 double incrementWidth = PageWidth;
                 double incrementHeight = PageHeight;
                 bool success = false;
@@ -423,7 +409,7 @@ namespace UnBox3D.ViewModels
                         {
                             incrementWidth++;
                             incrementHeight++;
-                            loadingWindow.UpdateStatus($"Retrying with new dimensions: {incrementWidth:0.##}m x {incrementHeight:0.##}m");
+                            loadingWindow.UpdateStatus($"Retrying with new dimensions: {incrementWidth} x {incrementHeight}");
                             await DispatcherHelper.DoEvents();
                         }
                         else
@@ -460,10 +446,8 @@ namespace UnBox3D.ViewModels
                     loadingWindow.UpdateProgress(50 + ((double)i / totalPanels * 30));
                     await DispatcherHelper.DoEvents();
 
-                    // SVGEditor works in millimetres (matches Blender's SVG output units):
-                    // PageWidth / PageHeight / PanelMargin are metres, × 1000 = mm.
                     await Task.Run(() => SVGEditor.ExportSvgPanels(svgFile, outputDirectory, newFileName, i,
-                        PageWidth * 1000f, PageHeight * 1000f, PanelMargin * 1000f));
+                        PageWidth * 1000f, PageHeight * 1000f));
                 }
 
                 loadingWindow.UpdateStatus("Exporting final files...");
@@ -1152,7 +1136,7 @@ namespace UnBox3D.ViewModels
                 ToastService.Show("Select a mesh first.", isError: false);
         }
 
-
+        
 
         [RelayCommand]
         private async Task ReplaceWithCubeOption(IAppMesh mesh)

--- a/UnBox3D/Views/MainWindow.xaml
+++ b/UnBox3D/Views/MainWindow.xaml
@@ -830,48 +830,34 @@
                                        Style="{StaticResource SectionLabelStyle}"/>
                             <Border Style="{StaticResource CardBorderStyle}">
                                 <Grid>
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                    </Grid.RowDefinitions>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="Auto"/>
                                         <ColumnDefinition Width="*"/>
                                         <ColumnDefinition Width="Auto"/>
                                         <ColumnDefinition Width="*"/>
                                     </Grid.ColumnDefinitions>
-                                    <TextBlock Grid.Row="0" Grid.Column="0" Text="W (m)"
+                                    <TextBlock Grid.Column="0" Text="W"
                                                FontSize="12" FontWeight="SemiBold"
                                                Foreground="{DynamicResource AccentBrush}"
                                                VerticalAlignment="Center" Margin="0,0,7,0"/>
-                                    <TextBox Grid.Row="0" Grid.Column="1"
+                                    <TextBox Grid.Column="1"
                                              Name="PageWidthTextBox"
-                                             Text="{Binding PageWidth, UpdateSourceTrigger=LostFocus}"
+                                             Text="{Binding PageWidth, UpdateSourceTrigger=PropertyChanged}"
                                              PreviewTextInput="NumericTextBox_PreviewTextInput"
                                              PreviewKeyDown="NumericTextBox_PreviewKeyDown"
+                                             TextChanged="NumericTextBox_TextChanged"
                                              LostFocus="NumericTextBox_LostFocus"/>
-                                    <TextBlock Grid.Row="0" Grid.Column="2" Text="H (m)"
+                                    <TextBlock Grid.Column="2" Text="H"
                                                FontSize="12" FontWeight="SemiBold"
                                                Foreground="{DynamicResource AccentBrush}"
                                                VerticalAlignment="Center" Margin="10,0,7,0"/>
-                                    <TextBox Grid.Row="0" Grid.Column="3"
+                                    <TextBox Grid.Column="3"
                                              Name="PageHeightTextBox"
-                                             Text="{Binding PageHeight, UpdateSourceTrigger=LostFocus}"
+                                             Text="{Binding PageHeight, UpdateSourceTrigger=PropertyChanged}"
                                              PreviewTextInput="NumericTextBox_PreviewTextInput"
                                              PreviewKeyDown="NumericTextBox_PreviewKeyDown"
+                                             TextChanged="NumericTextBox_TextChanged"
                                              LostFocus="NumericTextBox_LostFocus"/>
-                                    <TextBlock Grid.Row="1" Grid.Column="0" Text="M (m)"
-                                               FontSize="12" FontWeight="SemiBold"
-                                               Foreground="{DynamicResource AccentBrush}"
-                                               VerticalAlignment="Center" Margin="0,8,7,0"
-                                               ToolTip="Whitespace margin on every side of each board (metres). The inner (W - 2·M) × (H - 2·M) region is the usable cut area."/>
-                                    <TextBox Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="3"
-                                             Name="PanelMarginTextBox"
-                                             Text="{Binding PanelMargin, UpdateSourceTrigger=LostFocus}"
-                                             PreviewTextInput="NumericTextBox_PreviewTextInput"
-                                             PreviewKeyDown="NumericTextBox_PreviewKeyDown"
-                                             LostFocus="NumericTextBox_LostFocus"
-                                             Margin="0,8,0,0"/>
                                 </Grid>
                             </Border>
                             <Button Content="Export Unfolded (SVG/PDF)…"

--- a/UnBox3D/Views/MainWindow.xaml.cs
+++ b/UnBox3D/Views/MainWindow.xaml.cs
@@ -619,6 +619,34 @@ namespace UnBox3D.Views
             return true;
         }
 
+        private void NumericTextBox_TextChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)
+        {
+            if (sender is not TextBox textBox) return;
+
+            int cursorPosition = textBox.SelectionStart;
+            string originalText = textBox.Text;
+
+            if (string.IsNullOrEmpty(textBox.Text) || textBox.Text == ".")
+                return;
+
+            if (float.TryParse(textBox.Text, out float value) &&
+                textBox.DataContext is ViewModels.MainViewModel viewModel)
+            {
+                if (textBox.Name.Contains("Width"))
+                    viewModel.PageWidth = value;
+                else if (textBox.Name.Contains("Height"))
+                    viewModel.PageHeight = value;
+            }
+
+            if (textBox.Text != originalText)
+            {
+                int charsAdded = textBox.Text.Length - originalText.Length;
+                cursorPosition += charsAdded > 0 ? charsAdded : 0;
+            }
+
+            textBox.SelectionStart = cursorPosition;
+        }
+
         private void NumericTextBox_LostFocus(object sender, RoutedEventArgs e)
         {
             if (sender is not TextBox textBox) return;


### PR DESCRIPTION
temporarily revert to reapply with fixes in more convenient order